### PR TITLE
Add CI scan results and push learnings to strategy hub

### DIFF
--- a/analysis/reports/2026-02-15-ci-scan-summary.md
+++ b/analysis/reports/2026-02-15-ci-scan-summary.md
@@ -1,0 +1,80 @@
+# Competitive Intelligence Scan Summary — 2026-02-15
+
+> Date: 2026-02-15
+> Query: Full CI pipeline scan with --skip-memory (orchestrator run 20260215_173726)
+> Status: COMPLETED (classification skipped — no OPENAI_API_KEY)
+
+## Key Findings
+
+- **141 articles collected** from 41 RSS feeds across 11 competitor categories
+- **Tubi led press coverage** with 23 articles, followed by Peacock (20), Roku (12), Fubo (12)
+- **Roku posted $80.5M Q4 profit** — validates FAST model profitability, 145.6B streaming hours
+- **Tubi acquiring Cartoon Network content** starting March 1st — major content play for younger demographics
+- **YouTube TV launching cheaper bundles** including standalone sports package — threat to price-sensitive cord-cutters
+- **Samsung TV Plus reached 100M users** globally — OEM scale advantage growing
+- **Xumo confirmed at 411 channels** (21% more than Tubi's ~340) across 26 niche categories
+- **World Baseball Classic on Tubi** — Fox partnership delivering sports content to Tubi linear
+- **Peacock dominating live sports** — NBA All-Star, Winter Olympics 2026 coverage (20 articles)
+- **Fubo-Disney merger synergy** materializing with expanded reach for Fubo Sports Network
+
+## Article Distribution by Competitor
+
+| Competitor | Articles | Key Themes |
+|---|---|---|
+| Tubi | 23 | Content additions (Cartoon Network, classic movies), WBC, Valentine's |
+| Peacock | 20 | NBA All-Star, Winter Olympics 2026, live sports |
+| Roku Channel | 12 | Q4 earnings, new free channels, revenue growth |
+| Fubo | 12 | Disney synergy, sports coverage, pricing comparisons |
+| Samsung TV Plus | 6 | 100M users milestone, volleyball partnership |
+| Hulu Live | 6 | Daytona 500, Dark Winds, live TV comparisons |
+| YouTube TV | 6 | Cheaper bundles, sports plan, pricing breakdowns |
+| Amazon Fire TV | 5 | FA Cup streaming, device channel listings |
+| Industry | 49 | Fox Speed Channel return, Roku revenue, streaming ratings |
+| Plex | 1 | Free streaming roundup |
+| Vizio WatchFree | 1 | Walmart/Roku retail partnership post-acquisition |
+
+## Channel Count Snapshot
+
+| Service | Count | Method | Verified |
+|---|---|---|---|
+| Xumo | 411 | Slug count from page JSON | Yes |
+| Tubi | ~340 | User-confirmed (dynamic rendering required) | Partial |
+| Pluto TV | ~378 | Last confirmed via Playwright (dynamic JS) | Stale |
+| Samsung TV Plus | 300+ | Marketing copy | No |
+| Vizio WatchFree+ | 300+ | Marketing copy | No |
+
+## Learnings Pushed to Hub
+
+8 learnings pushed to `localhost:8888/api/strategy/learnings` (IDs 14-21):
+
+1. **Roku Q4 2025 profit turnaround** — $80.5M profit, 145.6B streaming hours
+2. **Tubi Cartoon Network acquisition** — March 1st launch, animation content play
+3. **YouTube TV cheaper bundles** — standalone sports package, pricing threat
+4. **Samsung TV Plus 100M users** — global scale milestone
+5. **Channel count snapshot** — Xumo 411, Samsung 300+, Vizio 300+, Tubi ~340
+6. **Fubo-Disney merger synergy** — expanded sports network reach
+7. **World Baseball Classic on Tubi** — Fox/FS1/Tubi broadcast schedule
+8. **Peacock live sports dominance** — 20 articles, NBA/Olympics coverage
+
+## Pipeline Notes
+
+- Classification phase skipped (OPENAI_API_KEY not set) — articles collected but not scored
+- Analysis phase skipped (no classified intel to analyze)
+- Memory phase skipped (--skip-memory flag)
+- Synthesis phase skipped (no classified data)
+- Channel scraping: Pluto and Tubi require dynamic rendering (Playwright) for accurate counts
+
+## Methodology
+
+- **Tool**: `python3 tools/scanner/orchestrator.py --skip-memory`
+- **Sources**: 41 RSS feeds (Google News, press releases, trade publications)
+- **Channel scraping**: Static HTML parsing of competitor channel pages
+- **Date range**: Default lookback (72 hours)
+
+## Follow-up
+
+- Re-run with OPENAI_API_KEY for full classification and analysis
+- Investigate YouTube TV sports bundle pricing impact on Tubi linear sports viewership
+- Track Tubi Cartoon Network content launch metrics post-March 1st
+- Monitor Roku Channel expansion — 9 new channels added, Pokémon among them
+- Verify Pluto TV channel count with Playwright browser automation

--- a/intel/scans/2026-02-15/20260215_173726/articles.json
+++ b/intel/scans/2026-02-15/20260215_173726/articles.json
@@ -1,0 +1,1274 @@
+{
+  "articles": [
+    {
+      "competitor_id": "samsung_tv_plus",
+      "source_label": "samsung_newsroom",
+      "title": "How to watch NASCAR in 2026: Weekly listings guide - NASCAR.com",
+      "url": "https://news.google.com/rss/articles/CBMibEFVX3lxTE1Tc19hY0FlVlV6Q3BaZXBTUHJSMDQ1SzdfRThFUlBPMGdYUXFlamZRNzI0Tkc2cG1uY281MFMzWUx3ZGR5eVRzTFBVU2NBdmdudmtTbXQzdDhSZ1I5LWJiOEpiRFpRUU4xWDBhag?oc=5",
+      "published_at": "2026-02-16T01:32:33",
+      "snippet": "How to watch NASCAR in 2026: Weekly listings guide&nbsp;&nbsp;NASCAR.com",
+      "hash": "a5c3e4a327d78149"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "cord_cutters_news",
+      "title": "Deal Alert: Lenovo IdeaPad Laptop Hits Record Low Price, Offering Premium Performance for Just $349.99",
+      "url": "https://cordcuttersnews.com/deal-alert-lenovo-ideapad-laptop-hits-record-low-price-offering-premium-performance-for-just-349-99/",
+      "published_at": "2026-02-16T01:17:00",
+      "snippet": "In a move that&#8217;s sparking excitement among tech enthusiasts and budget-conscious shoppers alike, Lenovo has rolled out an unbeatable deal on its IdeaPad laptop series, making high-end computing more accessible than ever. The Lenovo IdeaPad Laptop Computer, equipped with 20GB RAM, 1.2TB storage combining a 256GB SSD with 1TB cloud storage, an Intel Core processor, [&#8230;]\nThe post Deal Alert: Lenovo IdeaPad Laptop Hits Record Low Price, Offering Premium Performance for Just $349.99 appear",
+      "hash": "6f195e74d43016ab"
+    },
+    {
+      "competitor_id": "amazon_fire_tv",
+      "source_label": "amazon_fire_tv_news",
+      "title": "How to watch today's Birmingham vs Leeds FA Cup game: Live stream, TV channel, and start time - Goal.com",
+      "url": "https://news.google.com/rss/articles/CBMilAFBVV95cUxOVEE2YzcxZ3BaZEJRbWZxOTRkV3R2a284UWN6TkkxZTc5OFJ2VTNSV2cyajZ1U0dGdzVfcU9Objl3QWZKWXdFTnpTcWtyVkgyLXdYNTRMZFljY3NvSm5scnZpLXpFeDQxQm1fUzVJMjhOU2lWcWZaNVRCTkpHX2JuX0d6X3BRQ0tvcFVuTkF3aWlFXzZm?oc=5",
+      "published_at": "2026-02-16T00:11:15",
+      "snippet": "How to watch today's Birmingham vs Leeds FA Cup game: Live stream, TV channel, and start time&nbsp;&nbsp;Goal.com",
+      "hash": "18c849f29e217234"
+    },
+    {
+      "competitor_id": "tubi",
+      "source_label": "tubi_google_news",
+      "title": "5 Must-Watch Tubi Movies to Stream Right Now (February 2026): \u2018A.I.\u2019 and More - Us Weekly",
+      "url": "https://news.google.com/rss/articles/CBMiigFBVV95cUxQNWpZZkV4a2EwdkFMVl9QeDR3YXZfUVFGNlFDOGp4YWJEMVhyQ2F5NHVWVFQ4ZU1aN3JLYVZVaWI4ODdGM0RBdld1MVBtYmFQU1hIb182RjRrTDV1dVQzRDFXRUt0RXo1djQ3cHlJRlRZN3RhUTZ3cF9iVzlnRm1Eb21ZUEJvQnpXUlE?oc=5",
+      "published_at": "2026-02-15T23:37:31",
+      "snippet": "5 Must-Watch Tubi Movies to Stream Right Now (February 2026): \u2018A.I.\u2019 and More&nbsp;&nbsp;Us Weekly",
+      "hash": "bf7ccf341c7589cc"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "cord_cutters_news",
+      "title": "Fox Is Bringing Back The Speed Channel, But As A Part of FS1",
+      "url": "https://cordcuttersnews.com/fox-is-bringing-back-the-speed-channel-but-as-a-part-of-fs1/",
+      "published_at": "2026-02-15T23:13:01",
+      "snippet": "In a move that revives a beloved name in automotive broadcasting, Fox Sports has announced the return of the Speed Channel, this time reimagined as a podcast series airing on FS1. The new format aims to capture the essence of the original network&#8217;s high-octane content while adapting to modern listening habits, with episodes debuting weekly [&#8230;]\nThe post Fox Is Bringing Back The Speed Channel, But As A Part of FS1 appeared first on Cord Cutters News.",
+      "hash": "370b35db610283a4"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "the_verge",
+      "title": "OpenClaw founder Peter Steinberger is joining OpenAI",
+      "url": "https://www.theverge.com/ai-artificial-intelligence/879623/openclaw-founder-peter-steinberger-joins-openai",
+      "published_at": "2026-02-15T22:56:16",
+      "snippet": "Sam Altman announced on X that Peter Steinberger, the man behind the trendy AI agent OpenClaw, was joining OpenAI. He said that Steinberger has \"a lot of amazing ideas\" about getting AI agents to interact with each other, saying \"the future is going to be extremely multi-agent.\" He also said that this ability for agents [&#8230;]",
+      "hash": "2b568eab2b1ccfb1"
+    },
+    {
+      "competitor_id": "tubi",
+      "source_label": "tubi_google_news",
+      "title": "The Guy Ritchie\u2013Jason Statham Thriller That Flew Under the Radar Is Leaving Streaming Soon - Collider",
+      "url": "https://news.google.com/rss/articles/CBMitAFBVV95cUxPTFZncTJ6d3JiaVFFelpPdGdZM25veXU3cmQ3RXZtbktUbTRVQ19VcTN6ZzFWSXVxMnl3RkJDYkhUbDdFTGdVbTh6YUE1MnlLczZBek9jNktTd1hjWTBCd2t4bmk4WkthV0FPY01hdUpUS05fdTFJQWVBUU5mLWtVSGlobF9OdkRwWGxRZWxiSHhQR2toa1NSYnNsN1FsbmxyUDlRS1ZjLTQyQ3BPU3V2S3Fsay0?oc=5",
+      "published_at": "2026-02-15T22:40:12",
+      "snippet": "The Guy Ritchie\u2013Jason Statham Thriller That Flew Under the Radar Is Leaving Streaming Soon&nbsp;&nbsp;Collider",
+      "hash": "e70cf0686faa78e7"
+    },
+    {
+      "competitor_id": "tubi",
+      "source_label": "tubi_google_news",
+      "title": "The Best Sci-Fi Movie of the 2010s Discovers a Free Streaming Home Next Month - Collider",
+      "url": "https://news.google.com/rss/articles/CBMiggFBVV95cUxQS3Qxb0hPbXZtWjBiYV9VVUFmd1hKNGEyNWExeHk1YWFyalNjZHBpcV9YU2duWVRQd2g2VmVMd3MzeFJzcnRQaFZIRzBnOVNhcF9OajRRZmNnLW1VaGdwV2pJaUtsQnpLcGpVSHRRekdvbTJHd3R6ZXluNmswT1JsT0F3?oc=5",
+      "published_at": "2026-02-15T22:21:12",
+      "snippet": "The Best Sci-Fi Movie of the 2010s Discovers a Free Streaming Home Next Month&nbsp;&nbsp;Collider",
+      "hash": "d25cc3b7c27f0e8d"
+    },
+    {
+      "competitor_id": "tubi",
+      "source_label": "tubi_google_news",
+      "title": "Tom Hanks Solves a 'National Treasure'-Style Mystery on Free Streaming Next Month - Collider",
+      "url": "https://news.google.com/rss/articles/CBMisgFBVV95cUxOLV9qWXJPM3N1aW40RVZiZHVCb2QwUzVQcDRyMjFBUlRTMlp6c25ZMXlSQWpkRDhzMm8yd2F5ZmZVZ3VLa0pRTVk3WE5QU1pTYzN0czZfb1dNSUhTaXRlNzVtdXEyUE5tX0lla3pKZEpGb3FJUzJYV0RLb2x6SDZHYVJSN003REN5R2NYbHJFT0YwdS1mTlZoOEItUktZME9Od0RxVWJpR1JUSlZmOVpEcTFB?oc=5",
+      "published_at": "2026-02-15T22:01:12",
+      "snippet": "Tom Hanks Solves a 'National Treasure'-Style Mystery on Free Streaming Next Month&nbsp;&nbsp;Collider",
+      "hash": "0eacbcf92848316c"
+    },
+    {
+      "competitor_id": "tubi",
+      "source_label": "tubi_google_news",
+      "title": "4 Best Free Movies to Watch on YouTube, Pluto TV, Tubi and More (February 2026): \u2018Tropic Thunder\u2019 and More - AOL.com",
+      "url": "https://news.google.com/rss/articles/CBMid0FVX3lxTE10WTE4YlBfRC0xNkJpbnNKTkl6MkFlb0lTSHV2Y1RYQXNieWxxWWpIWVZwUkxVRGNaU1VWQ3pJT1JmOGUxaDNCa3hLTWNNVmZkMDhSVUZ1VGc5SFVWUkVpWGVMU3FGQ3Izdm8yLXRCRHVyWEtzSGc0?oc=5",
+      "published_at": "2026-02-15T21:45:12",
+      "snippet": "4 Best Free Movies to Watch on YouTube, Pluto TV, Tubi and More (February 2026): \u2018Tropic Thunder\u2019 and More&nbsp;&nbsp;AOL.com",
+      "hash": "ba93a2fa860b6aba"
+    },
+    {
+      "competitor_id": "roku_channel",
+      "source_label": "roku_news",
+      "title": "Roku just got several new free channels \u2014 here's what you can watch now - Tom's Guide",
+      "url": "https://news.google.com/rss/articles/CBMiugFBVV95cUxNYnlzVWZIMUZKaS1SblV0b1hCWldWN05kSC1Pa0h4X3YxQ2ZMeEtsX2RMRF9odGpubmg4cnJ5V29JNG92TUFPa2JjY2M2MU9pOWxtZ1pNLU9Cem1Hc2NaRkxfNlY4UXVJaFI5MUVRc0lRWmkzZVN0M01lQ1FyR3VWQ2dNOXdrWkdtT2dHUW5GVUtDQlJ0R2YzTkRLSjNpT1BRX3J1dFhnQUN6TUJsRExmdGNWS1UxcmRWZFE?oc=5",
+      "published_at": "2026-02-15T21:32:22",
+      "snippet": "Roku just got several new free channels \u2014 here's what you can watch now&nbsp;&nbsp;Tom's Guide",
+      "hash": "1f55f1dbf6375e26"
+    },
+    {
+      "competitor_id": "peacock",
+      "source_label": "peacock_news",
+      "title": "NBA All-Star Game 2026: How to Watch Team USA vs. the World Online for Free - Billboard",
+      "url": "https://news.google.com/rss/articles/CBMiuAFBVV95cUxOcEgtXzM3SnhSallVSFZyY0lGZHFuQjlIQVBXbXZxaTY5OGV0QUxNQkV3aXB0bE5aM2FTWHZBekc1SWRiVzVvdUR6XzNzbFhHeGpnZ3hZaGpjRFI1dHlGTFAzRERudFgwVzBDbTh0Nm00ckhFbjVqR3AtbXhEV1Q0R05tWlNiSXZRY01sN2xNRnMtZ29EcU5abWFKNjQ2MThaRTFfNTctdFlkdnByVFlWdk9VMml3M2dZ?oc=5",
+      "published_at": "2026-02-15T21:24:03",
+      "snippet": "NBA All-Star Game 2026: How to Watch Team USA vs. the World Online for Free&nbsp;&nbsp;Billboard",
+      "hash": "d4cca4f4129fb73d"
+    },
+    {
+      "competitor_id": "peacock",
+      "source_label": "peacock_news",
+      "title": "NBA All-Star Game TV Schedule for Today: Exact Start Time, Channel, Stream & Rules - Heavy Sports",
+      "url": "https://news.google.com/rss/articles/CBMibkFVX3lxTE01VTVqbkdxb0ZYS25COEx2Mjh2NmtsZDJhakNwUlE0R2ZRaE5WQ2dwNWNEUGUyMTNMN2xyVV95dUJRcVBWaE1UT2dyeUdPMUlmRGVJbGx6R1BSSURTamFnWl9PRnpPRV82MGpMc0Fn?oc=5",
+      "published_at": "2026-02-15T21:22:41",
+      "snippet": "NBA All-Star Game TV Schedule for Today: Exact Start Time, Channel, Stream & Rules&nbsp;&nbsp;Heavy Sports",
+      "hash": "a83d95fb39f22582"
+    },
+    {
+      "competitor_id": "peacock",
+      "source_label": "peacock_news",
+      "title": "How to stream NBA All-Star Game 2026 live without cable: TV and streaming info - The Big Lead",
+      "url": "https://news.google.com/rss/articles/CBMiqAFBVV95cUxQeXdzenBDLU9KR0NjQkFVWGtRNU9RbS1fdnMtSWVSZmNXN3A0dW9Zd2lIWWZuNFo3RS1UQ0RQSXRzOXRrR2twMWh0WlNxNHFydkhfT3dWa2Q2ZHBuMmVOZ09ZRFl4WGxaTDYzd0V0TUFLNmhoUG9RUzlqc1lSOUJRQzFSWmJHZE90MkZ0VU9wa1p6RmxTV1JOekEyTl82X3ZoN2ZmWi15LWk?oc=5",
+      "published_at": "2026-02-15T21:01:15",
+      "snippet": "How to stream NBA All-Star Game 2026 live without cable: TV and streaming info&nbsp;&nbsp;The Big Lead",
+      "hash": "420ea90d6447fb41"
+    },
+    {
+      "competitor_id": "peacock",
+      "source_label": "peacock_news",
+      "title": "How to Watch NBA All-Star Game 2026: Live Stream USA vs World, TV Channel - Newsweek",
+      "url": "https://news.google.com/rss/articles/CBMiqAFBVV95cUxPVEdBdkVic3BFVG42UDhqMUdZSG1pNFNvZXJRbEpfS2hIOEFUSzBJRk1aYzRNY3pqU1hJYzd0Q2l0TldDVFlRVDA4TUhUdkpVRXczSHdYRVZiNXkycTlMeENMWmE0RDVxWU9fTWpfX3JoM0hhcVQ4MW03UkIxYVJnVy15Uk4xWDVTMjdVWnZURmM2MWRqU3o2blZDTkc3THBnbXpjMmFodV8?oc=5",
+      "published_at": "2026-02-15T21:00:00",
+      "snippet": "How to Watch NBA All-Star Game 2026: Live Stream USA vs World, TV Channel&nbsp;&nbsp;Newsweek",
+      "hash": "9410fa07d8c23e31"
+    },
+    {
+      "competitor_id": "tubi",
+      "source_label": "tubi_google_news",
+      "title": "Hugh Jackman's Campy Horror Cult Classic Is Being Reclaimed on Free Streaming - Collider",
+      "url": "https://news.google.com/rss/articles/CBMipgFBVV95cUxNekZSMkMtbW9pa0tlSGF3WVd5dElaZGM3RnRpakxTd2pMbFRiYkRtdjBscTBiR3VzSExBdXgtR19NYzJ3dGdnRWJQY0N3U3hSSWU1bnpuU3FpX3h3WkljY05kVEh4YWRRZUctZHEzTk9lUHl4NTNhRlNPaURaeGlkbHpmRm5TNWdxWEtrazdYVWlQbS1BaG1ZWFItRlpPSncxWmswNEJR?oc=5",
+      "published_at": "2026-02-15T20:40:12",
+      "snippet": "Hugh Jackman's Campy Horror Cult Classic Is Being Reclaimed on Free Streaming&nbsp;&nbsp;Collider",
+      "hash": "d0b0c31dc54600b9"
+    },
+    {
+      "competitor_id": "peacock",
+      "source_label": "peacock_news",
+      "title": "Watch the 2026 NBA All-Star game streaming free today without cable; USA vs the World channel, time, rosters - OregonLive.com",
+      "url": "https://news.google.com/rss/articles/CBMi4gFBVV95cUxOb3lFNUpWbjlHWXZkRVh6LXBublplN0hmelZVTWpjWXg5QS10cDEtQkVYQWUzMjZReEMzUW9WdUdBYzBXQ0t1Rmg3bVFLTE00TGZPUGVpbTVud0dOVVpMWU52UVdUcHRHc2h3Q3o4cDV1RjluYldRdkpyV3VJVEpTWEQ0Y2d0blozbkh0eVdBYjEtOEYxZDA4NjZvN3RvNVNmNEtDWWQ2SThLbElWdENEemNoM3puNERFU0NaZVVrX1Z2clhhNGNsczFROGV5WWFfaGxYb0NYZXdPVzN1bnA1VlRR0gH2AUFVX3lxTE5xaVBXVXowTUNiZl9WcnZxdVdJTjVLVHJ0Q05RUlduU1gyN3JBQXVMQXVhMGh6TG9WbnJ6emo2bTdTb29HT3ZFbGRuWHEzRXNqdF9Ea0dpOThhRnVmWGg1NGNTdzlvTUE2YmFKSnZHZVBBeXhBZ2UyZXBQOU9VcncteUpvQ29FZ21ZZGxPRHRBeUx4MWtVZ0hQN29vNTIzWnlHYm9ITU9OTEY1dXNzNnp0MXRIV2NrRHctV0RBNzNtRW1va3NkM2J0VjVVVkhrUWdBeWVlTjVkeFNTbVlpVHJEVlU0WEFka1c2aXliQkwzZXdfSGdkQQ?oc=5",
+      "published_at": "2026-02-15T20:37:00",
+      "snippet": "Watch the 2026 NBA All-Star game streaming free today without cable; USA vs the World channel, time, rosters&nbsp;&nbsp;OregonLive.com",
+      "hash": "60909f3ab8c74c7b"
+    },
+    {
+      "competitor_id": "peacock",
+      "source_label": "peacock_news",
+      "title": "Live From NBA All-Star 2026: Peacock, NBC Sports Offer Viewers a Front-Row Seat With \u2018Courtside Live\u2019 - Sports Video Group",
+      "url": "https://news.google.com/rss/articles/CBMi0wFBVV95cUxQRm5LWWFZemtEZE9sa3hUbklLZ3d3NEw1QkhMRzFCT19ac3g5anpLVUJtZjBQNmtOOU1QR0owMlMxVkhZd2lRd28yYjRNVkpWc0t3dzkyNUNRWXVKU2tsRDk4T2xHWnpLSlBKcUFlSkRVZjJCa2NKYVBrRkFMQUV6S2FiajBHejZRUmtMSU4zMWlTVTFyejlueC1fLXY0UkZwR092UVM1VGNZSExCSGNXTzZXM21BZ2ZVckRnMmlXQUJqMkhRQnNzOXloNFZCOXV5aEEw?oc=5",
+      "published_at": "2026-02-15T20:16:03",
+      "snippet": "Live From NBA All-Star 2026: Peacock, NBC Sports Offer Viewers a Front-Row Seat With \u2018Courtside Live\u2019&nbsp;&nbsp;Sports Video Group",
+      "hash": "597ad0648aac0340"
+    },
+    {
+      "competitor_id": "peacock",
+      "source_label": "peacock_news",
+      "title": "How to watch the 2026 Olympics today: Day 9 schedule, where to stream free and everything else you need to know about the Winter Games - Yahoo Sports",
+      "url": "https://news.google.com/rss/articles/CBMimAJBVV95cUxPSzBVQ096Q2VRZ2NWbmFnblJHZkoyNzFUZ2o5V3gzQTNuLXpZN1hvbUI1dXBTOWk0TVlsZThlMExHLTl2dXN6amI0NDRoZU9XYlkwZUNLQlZtWDc2aWtuTS1Dck5nV2F2QjFCUk90Wm5NbTZpbnJldzkwUW11endrRGZ6QmNGNVJzNDZyN1ZxSTZsNWNOUklaeEo3LVRfZFVhQlYyRU5sWUJaaGtySDE0ei1mMDFWNFJKUVc0M3pHanNzaVdBdVlNaGZfRDUxM1FKamE5OFh6VVlzWm9rU2k2eTd3Y2tXOEVTcHU1VUU5Q1haMmJoYUk5eE1sRkFpYWxxZ2hHYnFwWkoyZUhHa2VrNG5RbVRKOEJO?oc=5",
+      "published_at": "2026-02-15T20:10:44",
+      "snippet": "How to watch the 2026 Olympics today: Day 9 schedule, where to stream free and everything else you need to know about the Winter Games&nbsp;&nbsp;Yahoo Sports",
+      "hash": "6041afe676252d37"
+    },
+    {
+      "competitor_id": "peacock",
+      "source_label": "peacock_news",
+      "title": "NBA All-Star Weekend 2026: How to watch, full events schedule, where to stream free and more - Yahoo Sports",
+      "url": "https://news.google.com/rss/articles/CBMi2AFBVV95cUxOWGFZT1Z1NVNjcnlfeWJNY083RWkxQ0lXZVM3N0FPbGFZTUUxNEpySjVPRG4tWTQzbU1wbzREUWg5aXQxOWIxZ3ZIeUQzS1BHcy1BYUZkajFTeFJTX1RxTGcxOXhxNHotVVFuZW5na3IwVGpObThjbERFdm8xOURjVzFpdzJHUmI4enRTdE03VUtyYmtOVmlTbDNrdDZPTVM2cVhwRkI2cUxEZXNpaVhITXd3ZUxGOEZyNTFJeUIxbVBQZk5UT3B4X0VMVFY2UU5FRTBrVmJ3MVM?oc=5",
+      "published_at": "2026-02-15T20:07:39",
+      "snippet": "NBA All-Star Weekend 2026: How to watch, full events schedule, where to stream free and more&nbsp;&nbsp;Yahoo Sports",
+      "hash": "a3f0870e24072b7d"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "cord_cutters_news",
+      "title": "Warner Bros. Discovery is Considering Restarting Talks to Sell to Paramount",
+      "url": "https://cordcuttersnews.com/warner-bros-discovery-is-considering-restarting-talks-to-sell-to-paramount/",
+      "published_at": "2026-02-15T20:05:55",
+      "snippet": "Warner Bros. Discovery has according to a Bloomberg report begun internal deliberations about potentially restarting merger discussions with the newly formed Paramount Skydance Corporation. This development comes as the media giant evaluates an updated proposal from Paramount Skydance, which could offer more favorable terms than its current commitments. The board at Warner Bros. Discovery is [&#8230;]\nThe post Warner Bros. Discovery is Considering Restarting Talks to Sell to Paramount appeared f",
+      "hash": "410166e29df00a56"
+    },
+    {
+      "competitor_id": "tubi",
+      "source_label": "tubi_google_news",
+      "title": "Before Sophie Turner\u2019s Reboot Rewrites History, 'Tomb Raider\u2019s First Major Misstep Hits Free Streaming - Collider",
+      "url": "https://news.google.com/rss/articles/CBMiywFBVV95cUxNbkkwa1JiLWRQVXVVUTZGeHlvdkM1cWthUWtEd3NlaDJpU0VUVzVQd1JMR0RpSno0eWNKakxwb1dIeEs4dWh1QThZYThES3dmM05MZ0I4ZHQ5RWdiZTJ4eWJVVEdZOWIzb3RzZG1NeDVockNmRF9kTzlLcEIyT09UUFpscnpTVGlRUV9wUlNJb1lfNjdkOVRLUFRDT1JCZ0JYLWtaYnB6UlY5a3BNcXdHczZpSVFmekloS0JfTmUzMkV5d2d4eXJVTzI0MA?oc=5",
+      "published_at": "2026-02-15T20:00:12",
+      "snippet": "Before Sophie Turner\u2019s Reboot Rewrites History, 'Tomb Raider\u2019s First Major Misstep Hits Free Streaming&nbsp;&nbsp;Collider",
+      "hash": "7a76c8a0050ae130"
+    },
+    {
+      "competitor_id": "peacock",
+      "source_label": "peacock_news",
+      "title": "Where to watch 2026 NBA All-Star Game (2/15/26) online without cable | FREE LIVE STREAM, Time, TV, Rosters - NJ.com",
+      "url": "https://news.google.com/rss/articles/CBMizAFBVV95cUxPQTlMVGxQMTZNc2FQNDZnUkxod3BVMnRlazhSWG5qSFJFYlFFYmItWk1yaUgzN1NhMHg1VU43cXdoRmtpUzQ3cXh3OGxTX0ljU2tNRERwRlRXSXZ2YzAxdFlRQUxBMDJBVldZZGdVRjd3SzJNbGNHSk1lT2tfTnpoY1d3Q2stZDRnUldTOTlWZnY2NmNkUF9pWDBTSHdaSzR6emlxQkJET0oxNGRpRU5CRTNHR0t6QWVjQVltVHNuUUVHVmh3d29pemtfNkbSAeABQVVfeXFMTWFFVDBmM1VHRzlVb3llby02bWNFVUVPdXVOZFlLUVMtaUVNZWs1TDhNQWlabHJ1S1o3NTdfSkxWbVJIMm1nczhQUnR0UHRfUGxDcnZyOEYxX3JwUHlId3JrcS1ZSFAtQXlQTDllZ2tZbWNhMUI4dlJLalBkbElTRmNxc3RDYWF3ZlYzcGItOTM3aUt5M2hzb1dQWE1CT045dUdlbVVMVV9FakdIX244U0VPWmh6S3RLVjNGT2xReWVLc0d3bUJJdEpxUFlIOS1wZ0RnbUNDdUVzX2Q4TmE2WWg?oc=5",
+      "published_at": "2026-02-15T20:00:00",
+      "snippet": "Where to watch 2026 NBA All-Star Game (2/15/26) online without cable | FREE LIVE STREAM, Time, TV, Rosters&nbsp;&nbsp;NJ.com",
+      "hash": "278d7b5c6745d443"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "cord_cutters_news",
+      "title": "Disney+ Adds TikTok Like Videos In Its Mobile App to Promote Its Shows Called Verts",
+      "url": "https://cordcuttersnews.com/disney-adds-tiktok-like-videos-in-its-mobile-app-to-promote-its-shows/",
+      "published_at": "2026-02-15T19:34:37",
+      "snippet": "Disney+ has rolled out an innovative feature that introduces vertical videos directly into its streaming app, transforming how subscribers discover and engage with the platform&#8217;s vast library of shows and movies. This new addition, designed primarily for mobile viewing, presents users with a scrollable collection of short, vertically formatted clips that offer quick glimpses into [&#8230;]\nThe post Disney+ Adds TikTok Like Videos In Its Mobile App to Promote Its Shows Called Verts appeared",
+      "hash": "278b2024a0df60bc"
+    },
+    {
+      "competitor_id": "tubi",
+      "source_label": "tubi_google_news",
+      "title": "28 Years Later, the Sci-Fi Thriller Ben Affleck Loathed Making Heads to Free Streaming - Collider",
+      "url": "https://news.google.com/rss/articles/CBMikwFBVV95cUxQTTlrZXpvVDlsVTN0UDkwei16dXhTOGs0TEpLV2pCY0JxMWk5WG03cnBJWE5CNTEtSTNKbXN6OUtnWEdhZVZOWlJobXNoRElaX0ZmNVFKVHkwSEdOMjZDYTAxNnowNE1lOURNMEtWLTctdERSUXNkRkx6WGdpWXU4YUIxOVlpQVBRbE1FamV5V1lxUjQ?oc=5",
+      "published_at": "2026-02-15T19:21:12",
+      "snippet": "28 Years Later, the Sci-Fi Thriller Ben Affleck Loathed Making Heads to Free Streaming&nbsp;&nbsp;Collider",
+      "hash": "d0e84400ca91d126"
+    },
+    {
+      "competitor_id": "peacock",
+      "source_label": "peacock_news",
+      "title": "How to watch Team USA vs. Germany: Start time, TV channel, and streaming info for Winter Olympics - Rink Royalty",
+      "url": "https://news.google.com/rss/articles/CBMiuAFBVV95cUxQSWZYb1lCYjU3UEpUZk04Y3hITTJCc3l2TmJqNi01VUFqcWpsMU1mcGlVb2dESkJOWjRrNjVPQTVMeVJBQ3lENHpBSGFNQ1JKYU5xc3A3Y1BCbU81U2xiUTJSZXNqYTJoRm9NRTNXRklLT1pEeGZXRzlZLTVkMmZWWUhfN2VOUm9mU2N2QWthQ3p0QkxGb0d3Rnl2ZW1ySmxHZjAxN082OE9FWng3NTNWbmF2NGJPMjhv?oc=5",
+      "published_at": "2026-02-15T19:20:37",
+      "snippet": "How to watch Team USA vs. Germany: Start time, TV channel, and streaming info for Winter Olympics&nbsp;&nbsp;Rink Royalty",
+      "hash": "a078b79fe349ea1f"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "ctv_advertising",
+      "title": "FAQ on CTV advertising: Trends, formats, and platforms to watch in 2026 - eMarketer",
+      "url": "https://news.google.com/rss/articles/CBMimwFBVV95cUxNWkdtY28wb1Zvc3g4ZWVyTWE4YVlDZ0h4enYxUlctbUFqYnVnamdpYWxUamxlUk13eVZlZlBVcFNNc3psWkcxVE45R1BabTRRUUNaQTlYN1FNcThfczlONVBfcHg2THZEUDZHXzhLbmFzelR5R0xfV09lbG92akpyU3h2U0NMY0laNWJ1akZjazZ6eGtld1lScFBZOA?oc=5",
+      "published_at": "2026-02-15T19:18:42",
+      "snippet": "FAQ on CTV advertising: Trends, formats, and platforms to watch in 2026&nbsp;&nbsp;eMarketer",
+      "hash": "d847572fa39cd41c"
+    },
+    {
+      "competitor_id": "hulu_live",
+      "source_label": "hulu_live_news",
+      "title": "How to Watch the 2026 NBA All-Star Game Online - The Hollywood Reporter",
+      "url": "https://news.google.com/rss/articles/CBMisgFBVV95cUxOSm10Ynp0RTFlbHYtVFlKdF9ZYXhvOUx4T3VHRkNjYTZ1RnN4Qk5WNEFsb0lNQUUzbVRxU0hlZVJla0k4Zm05TjNLb2RiUFY4U0FtT1MwbGpyWHIyMVM4bVh6NW0xd2RUQUZxTjRWTHdZRy1zVlhnQWZxT0ZZR0NTSDY1QVFYVGRpUkhjR3BOd3BJYXJYWnFpcHhqYXB5Nk51ODN5OUNJVUY0X0VrejBZNkRB?oc=5",
+      "published_at": "2026-02-15T19:18:32",
+      "snippet": "How to Watch the 2026 NBA All-Star Game Online&nbsp;&nbsp;The Hollywood Reporter",
+      "hash": "bc3bb66e413b1208"
+    },
+    {
+      "competitor_id": "peacock",
+      "source_label": "peacock_news",
+      "title": "NBA All-Star Game: How to Watch Today (Time, Channel, Stream) - Heavy Sports",
+      "url": "https://news.google.com/rss/articles/CBMidkFVX3lxTE1QemZiN2NWUnpkVUtVZVZRb0kzSHBnNHpyM0VqTzlCMzBJM0JqQURUWGxHOGMtd3g2ZWR3amREZWFGcjVIWERUdnZBSGRNNGVJcnRXcjFhb25NTWE2UTc3WkVpcWZNQ0wyaFR0RkNicUJ5MVBjcHc?oc=5",
+      "published_at": "2026-02-15T19:13:48",
+      "snippet": "NBA All-Star Game: How to Watch Today (Time, Channel, Stream)&nbsp;&nbsp;Heavy Sports",
+      "hash": "8df464d0e4e23f9f"
+    },
+    {
+      "competitor_id": "fubo",
+      "source_label": "fubo_news",
+      "title": "How to watch NBA All-Star Games for free today on DIRECTV and Peacock | LeBron James - Cleveland.com",
+      "url": "https://news.google.com/rss/articles/CBMisAFBVV95cUxPaC1sME5FTUhrMGZSUk9KRG41UHNwNU0xbFR5elFuVmlKNDRoODAxeTZsMXNRRkhMeEJ1d2RZN1hNbWtUYm83RmZjSU5BVEMwZzlZdWlMZ2ItVVlMeG05MnZFemJWdFpZZ240UGp0N1Y3dzFoSHpjcjdYWjliRFBXbjNlLVU5ZFZUTHFLcl9aT0lBQ2xKbjVLUy1haTZtT1oteHJrMjVXN01CM0xPLUxkSNIBxAFBVV95cUxPZ0NOdjh0VVZyVXViYVlLVlVmR2k0T1RZSXFsYVFTMUhRQzlXeFc4M2I1QXVmLW9oUVJ4LXZjRGN6SjVjRzBpZzdKQ2tJbWxOMG5XWXQtY1JIZFp1ZzVsa2pfNFItU0tCd1h5VTZsR3Q1QzBmS3lYMUxOMjQtS0pDaWhhVTdCV0RlNnN1LTEzU1Q0c2VMQTNKbUpUM0prbm9xbkx4QmZlcktfYy02b2NFdWN5MmhtYzVERkVyRTI1amtNY2Zr?oc=5",
+      "published_at": "2026-02-15T19:01:00",
+      "snippet": "How to watch NBA All-Star Games for free today on DIRECTV and Peacock | LeBron James&nbsp;&nbsp;Cleveland.com",
+      "hash": "4a1cc37aa16715a2"
+    },
+    {
+      "competitor_id": "roku_channel",
+      "source_label": "roku_news",
+      "title": "Chromecast vs Fire TV vs Roku: The Ultimate Streaming Device Comparison for 2026 - Techgenyz",
+      "url": "https://news.google.com/rss/articles/CBMicEFVX3lxTE5BZnNtWExMcDhVaEV0T0VVOVZIeFpfRHRUb21Zc3pfeWE3ZVVreGV6dkxFSnowdkF2OGNqODNUdUY4bE1WalFsT2NMOUxOSGh0aUttTTlodkg2dHBaMEpSR1FoR0RjTHVObktFblpHQ1k?oc=5",
+      "published_at": "2026-02-15T19:00:00",
+      "snippet": "Chromecast vs Fire TV vs Roku: The Ultimate Streaming Device Comparison for 2026&nbsp;&nbsp;Techgenyz",
+      "hash": "c63f30f8daf25fa3"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "cord_cutters_news",
+      "title": "Oakley Meta HSTN Smart Glasses Are On Sale Right Now",
+      "url": "https://cordcuttersnews.com/oakley-meta-hstn-smart-glasses-are-on-sale-right-now/",
+      "published_at": "2026-02-15T18:17:12",
+      "snippet": "Wearable tech that packs modern features, including state-of-the-art AI, just got a lot cheaper. For a limited time, you can upgrade to the Oakley Meta HSTN Smart Glasses for $339.15 (15% off), and enjoy hands-free photos, calls, and on-the-go AI help without lugging a phone. Featuring a 12MP camera, open-ear audio, Meta AI, and an [&#8230;]\nThe post Oakley Meta HSTN Smart Glasses Are On Sale Right Now appeared first on Cord Cutters News.",
+      "hash": "0a6ae00ade957fcb"
+    },
+    {
+      "competitor_id": "tubi",
+      "source_label": "tubi_google_news",
+      "title": "Brad Pitt\u2019s Underrated Space Odyssey Is About To Stream for Free - Collider",
+      "url": "https://news.google.com/rss/articles/CBMirgFBVV95cUxQUGZqeHFNa3pYdDVJcklRV0tTNFVEdUFULURTVzBpTktzQnBtVW01dGtvNkkybGQ3d19RNlQzdTR2RjBmYkFVN0NiWW02ZlZEYjBSWHBiQXEzQnVOTDRLRUpPZmI1aldvSG9Hbm9rVU11SWFGclkyZDZwZkI5RGEydjQ1MUtOeFVCTDBqdWdwS0NvSjlOV0tYY1BwWkJQZGZ1OV9va091Z25yR1FCOEE?oc=5",
+      "published_at": "2026-02-15T17:40:12",
+      "snippet": "Brad Pitt\u2019s Underrated Space Odyssey Is About To Stream for Free&nbsp;&nbsp;Collider",
+      "hash": "1bf48533ea5bdfbf"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "cord_cutters_news",
+      "title": "Ring Doorbells Are on Sale For Just $59.99 For a Limited Time & It Supports The Fire TV",
+      "url": "https://cordcuttersnews.com/ring-doorbells-are-on-sale-for-just-59-99-for-a-limited-time-it-supports-the-fire-tv/",
+      "published_at": "2026-02-15T17:37:05",
+      "snippet": "Want to see what is happening outside or inside your home from your Echo or Fire TV? Now, with the Ring doorbell cam or indoor cam, you can do just that, and they are both on sale right now. Just in time for its big Presidents Day sale, Amazon has its popular Ring Doorbells on [&#8230;]\nThe post Ring Doorbells Are on Sale For Just $59.99 For a Limited Time &amp; It Supports The Fire TV appeared first on Cord Cutters News.",
+      "hash": "ce967fbd13848c17"
+    },
+    {
+      "competitor_id": "hulu_live",
+      "source_label": "hulu_live_news",
+      "title": "'Dark Winds' Season 4: where to watch, start time, channel, 'Dark Winds' on Netflix/AMC+ streaming info - Decider",
+      "url": "https://news.google.com/rss/articles/CBMipgFBVV95cUxPYjdjTUFKVXY5bDM2YVVXSUVUX25UcHNPUHh1dWJld2txN3hEZDNILW9PTy1YeV9GYlNGMTExWkRmZUdKU3luWHdlN3pBaGZtWUphY05Dc0VyVmxzWFoyMFlIX3RlRGtTZURYMjBlczFaRjNNdEs4MEU3cXVCQTRpa25pNzcwdml2TmZIX1NMeFdkdVNKQmtTS3NuTzR1bHNCRkJkZEJR?oc=5",
+      "published_at": "2026-02-15T17:30:00",
+      "snippet": "'Dark Winds' Season 4: where to watch, start time, channel, 'Dark Winds' on Netflix/AMC+ streaming info&nbsp;&nbsp;Decider",
+      "hash": "4ce0061febc8d3ac"
+    },
+    {
+      "competitor_id": "peacock",
+      "source_label": "peacock_news",
+      "title": "USA vs. Germany Men\u2019s Hockey FREE Live Stream (2/15/26): How to watch preliminary | Time, TV Channel for 2026 - NJ.com",
+      "url": "https://news.google.com/rss/articles/CBMi5AFBVV95cUxOdVJGeEdRSjBScjJDOFRuQXlrWUxEbnVTTGxBMVIyTkRnaWtLZkJJQWZqN2poaDdzM2loemlPdkdVRnE2a0RwWDdQNzJMaGppYWkzOHZrMWNkVVAzT1hadWFFT21oYmtXcFFzemtQbUlhZXlNU0E0N2poNWxxUkY1VTBQQXctLXAxVXBTUlZsU0haWjlVd1Nzai1UQVphVjFDLS1VNXRGTm5uUmJkRW4zLTFOTi1kOEpDUFhENzE3a2RDaV96WVNCX3h1T0hrS1BFOWJJbl92NHhuNlRhTmJfNDdJM3DSAfgBQVVfeXFMTlkwcFJuRWR6R2JLX25zdkcwN0J0SmYxQmswYlFVRzJJQnl3eWI4VUtyUnZua1hndmRxQnJGaU1LbEVtQ2ZhRktUbmVfcl9MTUtGTDAzSFlqWHB6Vk1SVmFQRmM2WUxsY256Zk1CXzZ6d0lvdWxSQ3FkT0czV0FpYTA2YjVPWnEzYlphWGwxcHloUVZXcUFKNjVXVklnbURHMzAxV2NzRnozdmhGaEtXOFRhSm1FcERQR0F3MG9KZG16UnE3Zl9JeGVPNlYtWXQyOFZYS1FhZ0NRT0I2ZHRqajM3T1dCN1BGT1EzdU5nRTNDajlJNWxEM1o?oc=5",
+      "published_at": "2026-02-15T17:30:00",
+      "snippet": "USA vs. Germany Men\u2019s Hockey FREE Live Stream (2/15/26): How to watch preliminary | Time, TV Channel for 2026&nbsp;&nbsp;NJ.com",
+      "hash": "ffb245a6e444ce30"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "the_verge",
+      "title": "You need to watch the intensely surreal cult classic Possession",
+      "url": "https://www.theverge.com/entertainment/879602/cult-classic-possession-1981-review-isabelle-adjani",
+      "published_at": "2026-02-15T17:30:00",
+      "snippet": "Let me just say that I highly recommend you go into Possession blind. Don't watch a trailer. Don't even finish reading this. Go watch it now over on Shudder, Criterion, or Metrograph. It's also available through Kanopy or Hoopla if your library provides access. Then come back so we can talk about it in the [&#8230;]",
+      "hash": "afd78c78468b7967"
+    },
+    {
+      "competitor_id": "tubi",
+      "source_label": "tubi_google_news",
+      "title": "The Greatest Historical War Epic of the 1990s Is Streaming for Free Next Month - Collider",
+      "url": "https://news.google.com/rss/articles/CBMitgFBVV95cUxOd1NFTGFMSmQwSXNGNC13X2ZIbXAtTW9rQmhTS3hzNnlBR3lTLXZSUG1lS0lnM2RmVVJFMmN3SjlXQl9XZDRaNXlVRlZYU1A1blo0TThkLWJWaE5sd01Gcl9ZNkFTbHlPR1NtaTEtenlWTjdOTVNIZjM5UWhHMS14b2FlOUtSVVo0S09yMkRyN1B3ZVRmUEc1djZLenk0V3FVdUhLcTVjWVZXU3VqNEt1V1c1ekNSUQ?oc=5",
+      "published_at": "2026-02-15T17:20:12",
+      "snippet": "The Greatest Historical War Epic of the 1990s Is Streaming for Free Next Month&nbsp;&nbsp;Collider",
+      "hash": "94da7d76ca178299"
+    },
+    {
+      "competitor_id": "hulu_live",
+      "source_label": "hulu_live_news",
+      "title": "Where To Watch The Daytona 500: Start Time, Channel, Streaming Info - Decider",
+      "url": "https://news.google.com/rss/articles/CBMikwFBVV95cUxOdzd4Zlg0ZjVQcmc4TEZSa1E4Z3B6bEN0OGwyME8wbjg2djF4bFNwZks0VlhFUFlQVkNnMDRQQTgtazNscnBnbUFLUHFvUnN1SVNRWFpYQV9kUlZSVl9qcmxJS0R3MUhWWVNXVnBMeGNvOFBzekxSOUZ3UmQ3UkFZVGxqTk1yWWhmTEd4Q08wNkx1cVE?oc=5",
+      "published_at": "2026-02-15T17:00:00",
+      "snippet": "Where To Watch The Daytona 500: Start Time, Channel, Streaming Info&nbsp;&nbsp;Decider",
+      "hash": "a3a6db2859ca9f20"
+    },
+    {
+      "competitor_id": "tubi",
+      "source_label": "tubi_google_news",
+      "title": "The Greatest Dark Western Movie of All Time Comes to Free Streaming Next Month - Collider",
+      "url": "https://news.google.com/rss/articles/CBMiqwFBVV95cUxQTDlwMHN3aDczYUkxTTRVYzZETWJlWmxzUmhST3ZCR2h2aUhRYV9GbjAxUVZuYW5NcDE5RXVZRUdoc29qS3BJdTNEWnZhM244YmRYZGtaNV9YU2pTVGs0YlV1ZXpSVjNfV19DejEtQTNWckpISWQ5eXktTVZsaVo5QWlPVkJwd09ZTkZ4NG82ZU9oUjV5WFFfZ2VGaVNPMVlxeF9fRGdiZm5MTDQ?oc=5",
+      "published_at": "2026-02-15T16:41:12",
+      "snippet": "The Greatest Dark Western Movie of All Time Comes to Free Streaming Next Month&nbsp;&nbsp;Collider",
+      "hash": "32afe873c71da5df"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "the_verge",
+      "title": "Here are the 55 best Presidents Day deals we\u2019ve found so far",
+      "url": "https://www.theverge.com/gadgets/875949/best-presidents-day-sales-deals-2026",
+      "published_at": "2026-02-15T16:40:56",
+      "snippet": "Deals have been admittedly pretty dry since the holidays, but now that February is in full swing, we\u2019re starting to see strong discounts return across a range of categories. In fact, thanks to Valentine\u2019s Day, the Super Bowl, and \u2014 as of this weekend \u2014 Presidents Day, retailers are once again offering a slew of [&#8230;]",
+      "hash": "c03f2ca48bb9a418"
+    },
+    {
+      "competitor_id": "hulu_live",
+      "source_label": "hulu_live_news",
+      "title": "Where to watch the Daytona 500 today: Free live stream - Syracuse.com",
+      "url": "https://news.google.com/rss/articles/CBMimgFBVV95cUxOZ2JMRkdxMTlZVFZobFhfb0ZaZm96VVVXaVJ5cE9LLTJJNVIyN1JiQVd2QjZydzJYMUpRQ3BZT2dCUllJTjNCR1ZVLWNHZVhVbGU2eVBaX2dYTmlqYlk4UEJfWTZpTElrblh2N1pOb3daVVB6SWVmc081eXExeFRHTW05c2o1azhITGxfRVNuc2NXQVBPZ3FvMjBR0gGuAUFVX3lxTFA3d3E3VGVZYVpnWjdEeFQ0aGRWV2VRVWdvX3Y0cWRfd2VFcU9FUEhqeWJMNDQ3bHpDNUdJN3EwSngxR2RKeEViLWZZOVQzTllPNVVEQVNyT1lPdm12VjZ4cTljNTJoSzdTQ3YwbU9CckR6ZDJnanBabk9mZ0NfQ201bVpielVRZnBqSWJXMktkMkRXTmNuMVRaWG1PSWltMHJ0ZFdqWFZOWDEzMGJPQQ?oc=5",
+      "published_at": "2026-02-15T16:00:00",
+      "snippet": "Where to watch the Daytona 500 today: Free live stream&nbsp;&nbsp;Syracuse.com",
+      "hash": "e19e5ff54fddc969"
+    },
+    {
+      "competitor_id": "fubo",
+      "source_label": "fubo_news",
+      "title": "Where to watch Syracuse women\u2019s basketball vs. Clemson for free today - Syracuse.com",
+      "url": "https://news.google.com/rss/articles/CBMirAFBVV95cUxOT21zY1lZOWlzUk9WLVdJa2x3ZXhoeTc0RTRuWVItaDFGQXlaTnFwUmZ4REdpNndlNU92Y1RJS2p5WE4xelkwOWhuOFZfV0pqUDdpaVJvYUszUjNpSXR0RndzYTRKQjd1R0RjU3A1eFExbHQ5WmpXMEZncTFiTVVDZWlvOFpKVGVuZ3BuckFDUEQ1QlZ0QmRLaVJwVVlSYXFETTRzV29neTVvZjh20gHAAUFVX3lxTE4tTy1fTmtiNnZOejJmOEZzSFBVdW5OcEpiZmhHS3JmanAycXBWN2JoMDQyTkROMkVDdUlvdHVtaks0dmlvWldtMG1iNURBQWJGS19wc2xpSE5lOU1jcUU5bzVJc0tBZDlnRTB1Y2Z2VkQyTnNUQ29wbV9qNmsxVjJQVDNNZ3VxUnFUbDU2S2pPVU5mM0lWTmswS1ZWSkRPQnhMUlhlcEFNZlRDNUYyVVB1ZzRsdmFLNVZwcGJOcEljSw?oc=5",
+      "published_at": "2026-02-15T16:00:00",
+      "snippet": "Where to watch Syracuse women\u2019s basketball vs. Clemson for free today&nbsp;&nbsp;Syracuse.com",
+      "hash": "03e8a16904145bb6"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "cord_cutters_news",
+      "title": "FTC Pressures Apple on Alleged Political Bias in News Platform",
+      "url": "https://cordcuttersnews.com/ftc-pressures-apple-on-alleged-political-bias-in-news-platform/",
+      "published_at": "2026-02-15T15:56:03",
+      "snippet": "The Federal Trade Commission has stepped into the ongoing debate over media fairness by issuing a warning letter to Apple chief executive Tim Cook to scrutinize the company&#8217;s news aggregation service for potential ideological favoritism. In a formal communication released recently, the agency&#8217;s leader highlighted concerns that the platform may be amplifying content from progressive [&#8230;]\nThe post FTC Pressures Apple on Alleged Political Bias in News Platform appeared first on Cor",
+      "hash": "a8e038331ba5bd86"
+    },
+    {
+      "competitor_id": "fubo",
+      "source_label": "fubo_news",
+      "title": "How to Watch Arsenal vs Wigan Athletic: Live Stream FA Cup, TV Channel - Newsweek",
+      "url": "https://news.google.com/rss/articles/CBMipAFBVV95cUxNOE5UVGstVU9oY3dPT3hGb2NFUHF3TGJqMUlqMGV0c1RlQi04dDJHa1lTTDNzY1Rwa2YyaEdDOThjT3V4MmtZZzEyY2dYNUlnZTB1N2ZLYktDUVdfOU84ZWs1T3BSem14YkRXTEJjVlFiTlBqQXV5bUxFeFpIQzJubDhHSGhhWjRGRlpMeGZhMG9EdGVzVkluYTJMLXhidUZYX0s1Tw?oc=5",
+      "published_at": "2026-02-15T15:30:00",
+      "snippet": "How to Watch Arsenal vs Wigan Athletic: Live Stream FA Cup, TV Channel&nbsp;&nbsp;Newsweek",
+      "hash": "945b9f267ddc53ec"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "cord_cutters_news",
+      "title": "Deal Alert: Google Pixel 10 Pro XL Hits Market with Significant Price Cut Amid Growing Demand for AI-Integrated Devices",
+      "url": "https://cordcuttersnews.com/deal-alert-google-pixel-10-pro-xl-hits-market-with-significant-price-cut-amid-growing-demand-for-ai-integrated-devices/",
+      "published_at": "2026-02-15T15:28:04",
+      "snippet": "In a move that has captured the attention of tech enthusiasts and everyday consumers alike, the Google Pixel 10 Pro XL has been slashed by $300 from its original list price, bringing the cost down to just $899 for the unlocked Android smartphone in its Obsidian color with 256 GB storage. This 2025 model, equipped [&#8230;]\nThe post Deal Alert: Google Pixel 10 Pro XL Hits Market with Significant Price Cut Amid Growing Demand for AI-Integrated Devices appeared first on Cord Cutters News.",
+      "hash": "b0f50fe7c61969e9"
+    },
+    {
+      "competitor_id": "hulu_live",
+      "source_label": "hulu_live_news",
+      "title": "The NBA All-Star Game Is Back With a New Format: Here\u2019s How to Watch - Rolling Stone",
+      "url": "https://news.google.com/rss/articles/CBMivwFBVV95cUxQYmF6N1FaYjAyZkVBZGFWMEZYOFJIXzU4SUY2Q0xuMnRERi1OV3RQSkRJRzc0aGpaTldHTXhPUmhMNXBrQUE3XzZaRndka25TZXM2ajBma3A3akQ4d1hfcEZ4OExmTzNZWVl6SV9Rd1l6cG5yZU1uWGM3dEQtQW9nRXJMNzRrU2xVcW9nVVA3dWpKQ212Uzh0aUx1THNmZWdBZ2VuQTV4UDY1YjY4SktuRkM4OTdaNEJJbnMzSTJSbw?oc=5",
+      "published_at": "2026-02-15T15:00:00",
+      "snippet": "The NBA All-Star Game Is Back With a New Format: Here\u2019s How to Watch&nbsp;&nbsp;Rolling Stone",
+      "hash": "f1f81d10a7cf0fc1"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "the_verge",
+      "title": "I hate my AI pet with every fiber of my being",
+      "url": "https://www.theverge.com/gadgets/877858/life-with-casio-moflin-robot-ai-pet",
+      "published_at": "2026-02-15T15:00:00",
+      "snippet": "After a few weeks living with Casio's AI-powered pet, Moflin, I finally understand why my mother hated my Furby so much. The fuzzy, guinea-pig-adjacent puffball fits snugly in the palm of my hand. It's undeniably cute, in a weird kind of way, but the second it starts to squeak or twitch, I am hit with [&#8230;]",
+      "hash": "5c1099ac65ab3131"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "the_verge",
+      "title": "Logitech\u2019s new Superstrike is a faster, more customizable gaming mouse",
+      "url": "https://www.theverge.com/tech/879221/logitech-gpro-x2-superstrike-gaming-mouse-pc-hands-on",
+      "published_at": "2026-02-15T15:00:00",
+      "snippet": "Enthusiast gaming keyboard tech has made the jump to gaming mice - well, to one gaming mouse so far. The $179.99 Logitech G Pro X2 Superstrike is the first to feature analog sensors that use induction to register clicks faster than microswitches used in many mice. Those sensors allow for a host of cool features [&#8230;]",
+      "hash": "280cb91b91abadf9"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "the_verge",
+      "title": "Apple\u2019s first-gen AirTags are still worth buying now that they\u2019re $16 apiece",
+      "url": "https://www.theverge.com/gadgets/879325/apple-airtag-1st-generation-presidents-day-sale-deal",
+      "published_at": "2026-02-15T15:00:00",
+      "snippet": "With Apple\u2019s second-gen AirTags now widely available, we\u2019re already seeing inventory of the first-gen model begin to dwindle. Case in point? Amazon is no longer selling a single AirTag, and it\u2019s unclear when \u2014 or if \u2014 the retailer will restock the first-gen model. Thankfully, you can still grab a four-pack of the first-gen location [&#8230;]",
+      "hash": "c6f9ad93aebf26f4"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "cord_cutters_news",
+      "title": "38 Years Ago: \u2018Red Dwarf\u2019 Blasts Off into Sci-Fi Comedy Legend",
+      "url": "https://cordcuttersnews.com/38-years-ago-red-dwarf-blasts-off-into-sci-fi-comedy-legend/",
+      "published_at": "2026-02-15T14:51:15",
+      "snippet": "On this day in 1988, a quirky British sitcom set aboard a derelict mining spaceship revolutionized television comedy, blending science fiction with sharp wit and absurd humor. &#8220;Red Dwarf,&#8221; created by Rob Grant and Doug Naylor, premiered its first episode, &#8220;The End,&#8221; on BBC Two, introducing audiences to a universe where the last human alive [&#8230;]\nThe post 38 Years Ago: &#8216;Red Dwarf&#8217; Blasts Off into Sci-Fi Comedy Legend appeared first on Cord Cutters News.",
+      "hash": "06d2639b76727cfc"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "cord_cutters_news",
+      "title": "Soon, Every AM & FM Radio Station in Your Town Could Be Owned By One Company if The National Association of Broadcasters Has Its Way",
+      "url": "https://cordcuttersnews.com/soon-every-am-fm-radio-station-in-your-town-could-be-owned-by-one-company-if-the-national-association-of-broadcasters-has-its-way/",
+      "published_at": "2026-02-15T14:09:23",
+      "snippet": "The National Association of Broadcasters has intensified its campaign to push the Federal Communications Commission toward swift deregulation of longstanding broadcast ownership limits. In a detailed 87-page reply comment submitted on January 16, 2026, the NAB reinforced its position that current restrictions on local radio and television station ownership no longer serve the public interest [&#8230;]\nThe post Soon, Every AM &amp; FM Radio Station in Your Town Could Be Owned By One Company if Th",
+      "hash": "bb50c104bb98e183"
+    },
+    {
+      "competitor_id": "peacock",
+      "source_label": "peacock_news",
+      "title": "How to watch Olympic figure skating free live stream today: Sunday, Feb. 15 - MassLive.com",
+      "url": "https://news.google.com/rss/articles/CBMiqwFBVV95cUxPNnR4aXVIak5ncHBqVDFFak95QW9iUTI3a0Y0NjV1N2tjczVBUXZQTXpoQ3Ria0hqNDgtYUpkSEVGa1FSWEtSd29DOTMtTHZrNGR5eDM2SUxRUWhMOUFnRnFEcWF2X0RaYnI3b1doQWdsa0QxNlY3Nml2QUlDTERZb2RJN1FFSTdJckFyZFphZElPRndaNzIyZlRIY01zRjduY3ZESl9FRk9QTUHSAb8BQVVfeXFMTkphM3I3YmNMc1FCSFhoY2ltZ0p0aWU0YUR2ZlV6cTR1MmZpLXFZSHhYREdGUzZsYnVDanF4XzBrbEJMS0h1bzEwTFQ2aExsdGViNWhBaDhVakpxYVdxWTNxN3ZNeGVmdFdHaUhjejNzWTBnSXdIMG5tSnp5U3hlNFhLYlFCa2tYdE5PRFAzc3hIWHFYWUVfcmVORmQ2N1NOZWV4Ym1QWGRHZHFmY3E5NWF0TGxYVWx6aTMzUnlJZm8?oc=5",
+      "published_at": "2026-02-15T14:01:00",
+      "snippet": "How to watch Olympic figure skating free live stream today: Sunday, Feb. 15&nbsp;&nbsp;MassLive.com",
+      "hash": "36283ee867eb4a84"
+    },
+    {
+      "competitor_id": "roku_channel",
+      "source_label": "roku_news",
+      "title": "10 Free TV Streaming Platforms Worth Trying in February 2026 \u2014 Hidden Gems, Classics, & More - | Cord Cutters News",
+      "url": "https://news.google.com/rss/articles/CBMitgFBVV95cUxQSGRLaU9oVDFHSm5BWWRMb01LcnpQeXc2RVNRYjhNNkVvYkF0SW5pOHJxQkRST29iZFdTSXRwQzBDY3BoZzRpMkJSU1JaQnRsbXFhUkhYejRVOFNIREZmdGd1ajJ0V21XeGlVNXNBdkJ6M1ZCdkpST0FRRGo4Yk93RERVZFdsNlVkYW9QX3Z2ZHNwdW9IUzZHa1dGX0x2UjVuWmN1RzJYdUUxQzB3NVZyTlRvejYyd9IBvgFBVV95cUxONGpIdERTNHZaNFB2a0pVV0VNSW1vX3VXSnV0Z2lOUW01bEJ4NWRYeUFYbFJzZnp6Q1RwUFlWWERMN0RiajlNdmpva0x4VURiOHotSE52ZUlVVkhYYzBfdXVDd3RJc1BLVi1TTE9DV2pyc1dkVmVxN0FZM3FQeTdMUkpSUmJ6ZjYzZ3psLTN2akU2TXQ3eFZoYkZFNWplTDc5LXhJaTRGcGpRYzFYSzZnOEJnek50ZFNZVkYzTHZn?oc=5",
+      "published_at": "2026-02-15T13:53:55",
+      "snippet": "10 Free TV Streaming Platforms Worth Trying in February 2026 \u2014 Hidden Gems, Classics, & More&nbsp;&nbsp;| Cord Cutters News",
+      "hash": "57d552cf192fd41b"
+    },
+    {
+      "competitor_id": "tubi",
+      "source_label": "tubi_google_news",
+      "title": "One of the Bleakest & Most Disturbing Horror Movies in Years Is Streaming Free - MovieWeb",
+      "url": "https://news.google.com/rss/articles/CBMib0FVX3lxTE9NVUEtdjBWR29BaUwxeVJ6TnlFVGRBWmVKcnhWZm9OZWJRcS1NN3JQcjBqajQ2OTVUTTlsSXh0SjVnTDVWcmtwcEpxaThhU2pqRkNNemRib01US3J1R2o3QV9iMUZrNkd6LXhYWnN6OA?oc=5",
+      "published_at": "2026-02-15T13:00:17",
+      "snippet": "One of the Bleakest & Most Disturbing Horror Movies in Years Is Streaming Free&nbsp;&nbsp;MovieWeb",
+      "hash": "bcf3eabecbe07339"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "the_verge",
+      "title": "Why are Epstein\u2019s emails full of equals signs?",
+      "url": "https://www.theverge.com/policy/879016/epstein-files-emails-text-errors-encoding",
+      "published_at": "2026-02-15T13:00:00",
+      "snippet": "Many of the emails released by the Department of Justice from its investigation into Jeffrey Epstein are full of garbled symbols like: Or: The scrambled text is so ubiquitous that it's spurred conspiracy theories that it could be some kind of code. But as believable as it might be that a cabal of elite sex [&#8230;]",
+      "hash": "8bd6745e5e365b78"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "the_verge",
+      "title": "AI can\u2019t make good video game worlds yet, and it might never be able to",
+      "url": "https://www.theverge.com/column/879524/ai-video-game-worlds-project-genie",
+      "published_at": "2026-02-15T13:00:00",
+      "snippet": "This is The Stepback, a weekly newsletter breaking down one essential story from the tech world. For more news about video game industry's pushback against generative AI, follow Jay Peters. The Stepback arrives in our subscribers' inboxes at 8AM ET. Opt in for The Stepback here. How it started Long before the generative AI explosion, [&#8230;]",
+      "hash": "bba8d59a70f654ba"
+    },
+    {
+      "competitor_id": "youtube_tv",
+      "source_label": "youtube_tv_sports",
+      "title": "YouTube TV\u2019s New Cheaper Plans Are Now Live, But There is A Catch - | Cord Cutters News",
+      "url": "https://news.google.com/rss/articles/CBMilwFBVV95cUxPRkNwZTFjbnRSVTB4cVVOY2k3b3pjcDR5Nmc3TDZOX0Y3c3l5TXVrOUQ1bGsyUGRuV0xEVHppU0wzWFZTSXUtb3RqVFkxczE0YUpyWFg1RG1rMHpWeGR0RmNmSTUwY1hGYmd4OGFLcExSWWtfUnd0cWZNXzZkVDJHbHZZUGFsQWQzRlZ6MDBwLUFvT3hxMi1n0gGfAUFVX3lxTE9UQXVPczlLRG9aR3FWTnRTOWxhZDBEbjVYYUNUNDM4NVFhRkhjTXh5MktsVzJLOTROSHl6a2ZoX3Noc3g4bjdKTVh3ZEstTFd3NDJ0ZHBRdzRobldoU0JpbkNjNlQwcmk5LS15b3p1VFF4cXQ4QW5GbFkwYzRpcnctS2hmUm81Q1VlTElWWnA4eVhrd19ibUMyeU1lRi1lNA?oc=5",
+      "published_at": "2026-02-15T12:35:02",
+      "snippet": "YouTube TV\u2019s New Cheaper Plans Are Now Live, But There is A Catch&nbsp;&nbsp;| Cord Cutters News",
+      "hash": "70b942beed6986d7"
+    },
+    {
+      "competitor_id": "roku_channel",
+      "source_label": "roku_news",
+      "title": "Your Roku just got 9 more channels to watch for free - including a big one for comedy fans - ZDNET",
+      "url": "https://news.google.com/rss/articles/CBMijwFBVV95cUxNOW9yTURUN2k4LTZkUExoZHZhUnFzTExyeG03N0xMNlBOZVpiMlc1dGc0UnZlNDI3d0h0NGhPT0puUUdHdnA5RFNTZk4tcTF6RVJtOW9PZkg0TFY5MExkUDFPUnJFTmV1bmkzYXJUQ1lSeEYtTEROaHVhYmNKUFRKWXV6dnVHR0hmRmRrUnZzVQ?oc=5",
+      "published_at": "2026-02-15T12:00:00",
+      "snippet": "Your Roku just got 9 more channels to watch for free - including a big one for comedy fans&nbsp;&nbsp;ZDNET",
+      "hash": "a36cdda8ccc893f3"
+    },
+    {
+      "competitor_id": "fubo",
+      "source_label": "fubo_news",
+      "title": "Disney's merger synergy kicks in as Fubo Sports Network reaches millions of new streaming viewers - PPC Land",
+      "url": "https://news.google.com/rss/articles/CBMitAFBVV95cUxOUmdNX3NIc2ludThQRHB1c0piMjRtXzdoZGRDQlducy1LRlRmSlloc0lpcXRSNmFKbEVnZlhWY0xMczFGZ2VBMjd1ekh6eGo1NkwwaHNvSGpIS3RHTnNEOWtvbXNaRDJGLXRZQXJPa1pOU3BZWHBGbDRXNUdaZVNOVGNvU1E0ZVV0c3I2VzZ2RUZud1RpWTJhVmJMVlEyRWlfM1Jwa3FkdlhIYzFFa1VKVlRZZVI?oc=5",
+      "published_at": "2026-02-15T11:09:14",
+      "snippet": "Disney's merger synergy kicks in as Fubo Sports Network reaches millions of new streaming viewers&nbsp;&nbsp;PPC Land",
+      "hash": "8e051a0dec797863"
+    },
+    {
+      "competitor_id": "peacock",
+      "source_label": "peacock_news",
+      "title": "Snowboarding FREE Live Stream (2/15/26): How to watch mixed team cross final| Time, TV, Channel for 2026 Wint - NJ.com",
+      "url": "https://news.google.com/rss/articles/CBMi2AFBVV95cUxOSWhRREFKeTlPUUFfeFpIY1hGZGxlb1hISU1iSG03Q0t3VHVsc3lLTnB3OVpMdmpRTHowTko0anBBNFZseVA1UE5iODJydGJ6RFlwamFVcklrLTNfZUFweUZnTE1YYXZHZTZHYVp5cWZkMXJ5dEZfOUJIcmRuRmFhYXNpeDZ6WmxMX3V0bm1lS3JtRGhRT3lURnUxS1V3Z3pMZVV5T0owU0RpSFlCWEdHbjVnY1ltVHhNTjNfR2dvYjRBdjA5UlZsdnVDNUNrVUxxNlpKdlVHeTPSAewBQVVfeXFMUEJaMUowbEJiSzZMMk80VFo0X3hZaVE5YTlSXzFsc2JyZGFtWHM1MDVLdU5CYzNvQ2hNdTRiWHZGcWlXN3p0MUpmNUx2S3ZaWkdWaUhyOVFMVHg0cEdnR0diZUQxNWcyWGVsUWNuM2FDa2pPUGx4cElDWEZINXNmWGdRdmItRmZkWENTaG5uMW1nWWJsbjBqclRKX2ZYN29heGZwcHRMSlVHZXZEaDF5WTAzWGJiYVdLUmZBTGdhaEhMN3JDeHFfRVpHYnlWbkMwTGRWZnY0ZGduM2tUdm5LcF9FT0dHT1YwQWtuWDM?oc=5",
+      "published_at": "2026-02-15T11:00:00",
+      "snippet": "Snowboarding FREE Live Stream (2/15/26): How to watch mixed team cross final| Time, TV, Channel for 2026 Wint&nbsp;&nbsp;NJ.com",
+      "hash": "b9fd53100218ad9d"
+    },
+    {
+      "competitor_id": "amazon_fire_tv",
+      "source_label": "amazon_fire_tv_news",
+      "title": "What channels do you get with an Amazon Fire TV Stick? See if Netflix is included - Yahoo News UK",
+      "url": "https://news.google.com/rss/articles/CBMiekFVX3lxTE41a1FkRjZJQ21qQVI0WFU4RklKU0ZNZ3lSRkNEVFVlRXpkTjM0WjFNRXZkWEdsd2trd19JVmpIdUswby1VazZaLVg5b1dPNGNNWGNKemI1YkcyOXhmYVQ1NnN6NmdrUl96VHhkQVlCT29tU2hTZGw2RWFB?oc=5",
+      "published_at": "2026-02-15T10:55:29",
+      "snippet": "What channels do you get with an Amazon Fire TV Stick? See if Netflix is included&nbsp;&nbsp;Yahoo News UK",
+      "hash": "741d425fa0bc55cf"
+    },
+    {
+      "competitor_id": "amazon_fire_tv",
+      "source_label": "amazon_fire_tv_news",
+      "title": "What channels you get with an Amazon Fire TV Stick and if Netflix is included - Tivyside Advertiser",
+      "url": "https://news.google.com/rss/articles/CBMipgFBVV95cUxQMXRwelB4QndHT2VucU1iakF3MzdTYmVKa2VGZ2d0NnRPM3c2NV8zRHpOTG95dU5iN0ZtZVlibE51Vy1nY2d4U0NhR1I1b2loQ2FEZGFSeXBuTDZOd1dRdnhaY0pWeVd3MEVWOWM5YktObzFKSDdmdXpkRXJHbVk5eWVjYkMzTWg0eFNuWWtZN256ZElqS3F6R1hRb0RZby1hUHZ4Qkx3?oc=5",
+      "published_at": "2026-02-15T10:55:29",
+      "snippet": "What channels you get with an Amazon Fire TV Stick and if Netflix is included&nbsp;&nbsp;Tivyside Advertiser",
+      "hash": "e76f09e10490ab4f"
+    },
+    {
+      "competitor_id": "peacock",
+      "source_label": "peacock_news",
+      "title": "Winter Olympics 2026 TV schedule, free streams during NBC blackout on FuboTV: Feb. 15 - PennLive.com",
+      "url": "https://news.google.com/rss/articles/CBMiwAFBVV95cUxQb3JGZGpubFppLW5QbUprQTNoWlhIdmJGd1Q4YXJpUkotTUV3T2g2MUI4S3Q4clhHN200S2VENWtJRUJxWktNS0xMMzJHU25uZE1NYkQybks2M285bVB0Q0p4WjJHemw4RlNpVjROX0hIQzl3aXk4NE92NHdydTRYU2lYZ05aVUV5LXFzd3daN1BUV0V3eFNSRTBPWjd0X3RsYmp3MEdfNDlQWmFMNnBBZGhjWkYxaG1tSlpVRlRaa3jSAdQBQVVfeXFMTllOR09jR3d0eUVxZDMwQVhoVmd3NkRybGxPNm9UMlctMUl0RUJPM2ozSldyLU1LWjRLNXNIaHhVNEZsOEpzaXljRElXVGhjTWl2TlBoQnM4dE5uckJ3NGNtREM5X3RhYXlMRjhRanA5a212M2VSQUxvNmExRUlSZzZEX0FYM3lselJrQjFqWWhBNnZ3MHd2akVQMUFQUV9OWFJOTWU1ZEF2NlZMU0cxQS1YbHNlZng2STJUREt5SGhqVjdya2tYNFdGa245bDNmcFRCTWU?oc=5",
+      "published_at": "2026-02-15T10:00:00",
+      "snippet": "Winter Olympics 2026 TV schedule, free streams during NBC blackout on FuboTV: Feb. 15&nbsp;&nbsp;PennLive.com",
+      "hash": "a626b02633a77615"
+    },
+    {
+      "competitor_id": "peacock",
+      "source_label": "peacock_news",
+      "title": "Winter Olympics TV schedule today: How to watch every event on Sunday - USA Today",
+      "url": "https://news.google.com/rss/articles/CBMisgFBVV95cUxQRHRrUUZFS3JBWFF1dU5ZZVhycloySUdfdGtQQTlJLXE5bDNKaHhPT2xVN0ptUHlULVVTbGVWcXhSMm5zbGlTZ0FYZ0VQVVhzLUxoMHh2TE9iNkNRUjN2UjFrX3IyNXVZY0pOX056NjJLNXB4Vm9lLTNUaUFZQkQ1WGpWZlk4Q2ZyelhnUnVCMTdVSHM4VmNtUVdZM2tWMV8zbmgwU3hWM055M1JaMG5kUndB?oc=5",
+      "published_at": "2026-02-15T09:30:00",
+      "snippet": "Winter Olympics TV schedule today: How to watch every event on Sunday&nbsp;&nbsp;USA Today",
+      "hash": "051ead871eb5fe85"
+    },
+    {
+      "competitor_id": "fubo",
+      "source_label": "fubo_news",
+      "title": "Here's What the Street Thinks About FuboTV (FUBO) - Finviz",
+      "url": "https://news.google.com/rss/articles/CBMigwFBVV95cUxQRHhzN0ZPbDNDMW1tenVTZ3JXMGJCV0J0Ymw3a1VpcW1HRHd1b2lxamVqUk5yN1otdzF4OFNPa21xTFFJbHo1U2ZEMnJMZjRSSUNPazc5N3I1Y1gzRjc0aTBkSXBnXzdFQWQ2MFAzTmFTWFQ5R1JHRlFiSTl6VHhWYy1nNA?oc=5",
+      "published_at": "2026-02-15T09:28:36",
+      "snippet": "Here's What the Street Thinks About FuboTV (FUBO)&nbsp;&nbsp;Finviz",
+      "hash": "87f89d067ecbf6ba"
+    },
+    {
+      "competitor_id": "peacock",
+      "source_label": "peacock_news",
+      "title": "The Winter Olympics Schedule Today, February 15, 2026 (Where to Watch) - NBC",
+      "url": "https://news.google.com/rss/articles/CBMimAFBVV95cUxQU2JoQ1VKRm9pOVoxbEpZSEk4QUREXzUzeW9YOGRScElCcmlxMTB3d0RLRnZYX2xFNVVWUGdCQTNWZ0NoYmxpYWpTSjRHd0p2cDk1UU0zQWF2TGJVSjBsRlBFMlhlRV96SjdUZnVKZUEtZVY0UnowMWNzS01oazU0T05sb29yWEtTZURaSUFJUlNCRm5mTWhiaQ?oc=5",
+      "published_at": "2026-02-15T05:06:03",
+      "snippet": "The Winter Olympics Schedule Today, February 15, 2026 (Where to Watch)&nbsp;&nbsp;NBC",
+      "hash": "b5134da63cc7921e"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "variety_streaming",
+      "title": "Paramount Sends ByteDance Cease-and-Desist Letter Over Seedance AI Videos, Alleging Intellectual Property Infringement",
+      "url": "https://variety.com/2026/film/news/paramount-disney-bytedance-cease-and-desist-seedance-ai-infringement-ip-1236663663/",
+      "published_at": "2026-02-15T04:57:45",
+      "snippet": "Paramount Skydance accused ByteDance of engaging in &#8220;blatant infringement&#8221; of its intellectual property with its Seedance video and Seedream image generative AI platforms, alleging the Chinese internet giant is illegally ripping off IP including &#8220;South Park,&#8221; &#8220;Star Trek,&#8221; &#8220;The Godfather,&#8221; &#8220;Dora the Explorer&#8221; and more. The media company sent a cease-and-desist letter Saturday to ByteDance, [&#8230;]",
+      "hash": "f87d42883ac4be00"
+    },
+    {
+      "competitor_id": "tubi",
+      "source_label": "tubi_google_news",
+      "title": "10 Terrifying Horror Movies You Can Stream for Free - MovieWeb",
+      "url": "https://news.google.com/rss/articles/CBMiakFVX3lxTE5UbUI1d3ptTW1QM0VRTXBtMko3ampoT3lqUnM0aGQtWlQ0VUZPSnN0cVBkbWRRLUloM3ZvVE9kTDNOdGcyMWNGTG15WW4xWjFPLVZwRzdCQTZUU1NRRUhnM1lyVGt6dFcyd3c?oc=5",
+      "published_at": "2026-02-15T03:00:00",
+      "snippet": "10 Terrifying Horror Movies You Can Stream for Free&nbsp;&nbsp;MovieWeb",
+      "hash": "d18ffd53acf28120"
+    },
+    {
+      "competitor_id": "amazon_fire_tv",
+      "source_label": "amazon_fire_tv_news",
+      "title": "Why There's Simply No Need For An Amazon Fire TV Stick Anymore - bgr.com",
+      "url": "https://news.google.com/rss/articles/CBMifkFVX3lxTE5CbV84UGZGOW1LLW1XTkZHVHNwNHBtYWtJRmhEaldtUlFsRHZIenIwUUk1bmFuS1JsMkFCell3YXloZ0JESlNVRTFJRkhNUlhtclZwM3ZUdjVrQU5vM05rR1RnbGJpZ1JyUGNHTUhjOXpKRDVDUUFzNkNSWVBJQQ?oc=5",
+      "published_at": "2026-02-15T00:17:00",
+      "snippet": "Why There's Simply No Need For An Amazon Fire TV Stick Anymore&nbsp;&nbsp;bgr.com",
+      "hash": "e9c21ba88918f800"
+    },
+    {
+      "competitor_id": "tubi",
+      "source_label": "tubi_google_news",
+      "title": "Need a Valentine\u2019s Day movie? An unlikely streaming service has the perfect pick - The Mary Sue",
+      "url": "https://news.google.com/rss/articles/CBMikwFBVV95cUxPYjBXeDl1TlBXZ29CZGVGWi1SbWVPVXhFOGFUZ1oyVFJvaFpweXcyTFZKYnVDNjhDUDVvODRoMFlrZFdYMzBISHBreDBSTWJWUUVZdlkycUZMM2xQS1pONTVDcVRya3lTLW54djhXcFhOei1IcG1IYWFfdVpMZUlxSWNBTlhsYUFEZDRTeDhkWUNITGc?oc=5",
+      "published_at": "2026-02-14T23:52:00",
+      "snippet": "Need a Valentine\u2019s Day movie? An unlikely streaming service has the perfect pick&nbsp;&nbsp;The Mary Sue",
+      "hash": "5c6a674ea83438f0"
+    },
+    {
+      "competitor_id": "tubi",
+      "source_label": "tubi_google_news",
+      "title": "'Gladiator' Fans Are Running Out of Time to Stream This Historical Action for Free - MovieWeb",
+      "url": "https://news.google.com/rss/articles/CBMibkFVX3lxTE1VeHMzU1dtNHJMaXhTWm4zU2hRWnB2Z2R1aEhlMlFQOU9EM1ZQQlNrS2dzdnpjaHFMTWU3WVJBRUdhdzZGMklkZTJxSjJ1Mkk3Yjk1akJSTjZRdkJfckhRemdjcnJrVnRZOVVvbkpB?oc=5",
+      "published_at": "2026-02-14T23:00:17",
+      "snippet": "'Gladiator' Fans Are Running Out of Time to Stream This Historical Action for Free&nbsp;&nbsp;MovieWeb",
+      "hash": "e83a6d4902f5ba8d"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "the_verge",
+      "title": "Jikipedia turns Epstein\u2019s emails into an encyclopedia of his powerful friends",
+      "url": "https://www.theverge.com/policy/879508/jikipedia-epstein-email-encyclopedia",
+      "published_at": "2026-02-14T22:33:02",
+      "snippet": "The folks behind Jmail are at it again with a clone of Wikipedia that turns the treasure trove of data in Epstein's emails into detailed dossiers on his associates. Entries include known visits to Epstein's properties, possible knowledge of Epstein's crimes, and laws that they might have broken. The reports are dense, listing how many [&#8230;]",
+      "hash": "0516f4e460f2fb23"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "variety_streaming",
+      "title": "Barack Obama Reacts to Donald Trump\u2019s AI Video Depicting Him as an Ape: \u2018There Doesn\u2019t Seem to Be Any Shame About This\u2019",
+      "url": "https://variety.com/2026/digital/news/barack-obama-reacts-donald-trump-ai-ape-video-1236663606/",
+      "published_at": "2026-02-14T21:55:43",
+      "snippet": "During a recent appearance on Brian Tyler Cohen\u2019s podcast, Barack Obama gave his reaction after an AI video was posted to Donald Trump&#8217;s Truth Social account that depicted the former president and his first lady, Michelle, as apes. Obama opened his thoughts by calmly stating that it\u2019s \u201cimportant to recognize that the majority of the [&#8230;]",
+      "hash": "0ee5889f42b3d156"
+    },
+    {
+      "competitor_id": "tubi",
+      "source_label": "tubi_google_news",
+      "title": "Tubi Becomes the New Cartoon Network Next Month - Gizmodo",
+      "url": "https://news.google.com/rss/articles/CBMihAFBVV95cUxQVFRvUERVUnBDeVhkaWdSTF9IV1hyLWZGQXFST1R5b1dXMS1XUGpVQ3hHa2kxSXREQW0yRHlINW9yM1JNZVpuNnVWS0R6U3RLVDRJWV9WN1NjMlhKbEJGdllNNkptU1Z6SGc0NUpnMUJmOHRVa1l2N3VJYXJwWWpfeE5tWWk?oc=5",
+      "published_at": "2026-02-14T21:15:00",
+      "snippet": "Tubi Becomes the New Cartoon Network Next Month&nbsp;&nbsp;Gizmodo",
+      "hash": "da5359f5a44f4501"
+    },
+    {
+      "competitor_id": "tubi",
+      "source_label": "tubi_google_news",
+      "title": "March 1st Will Be a Great Day for Saturday Morning Cartoons Fans (Thanks to Tubi) - ComicBook.com",
+      "url": "https://news.google.com/rss/articles/CBMitwFBVV95cUxPQnhPX2I2N05TNnZqUVVVbklKbDgzTm14ZnFFNUJha011Q0l6bDk5VW5ReUZ5WEgxQnFpRVYxY0ZlMEswZG5sZVR4eTB3WjNWSTE3bTFMamF5cG5tbnozd2tPdjVSM3VIb1hJRklwTE5DY1FJTDkxVndEVWhFeTJHVGR4Z3E4VHZmZlJQSlJHTXA0VUFrQlByX0hSeFh0bEs4aGV3c1EtNUNJSlFQV0E2VzJTbVQ0akU?oc=5",
+      "published_at": "2026-02-14T18:30:00",
+      "snippet": "March 1st Will Be a Great Day for Saturday Morning Cartoons Fans (Thanks to Tubi)&nbsp;&nbsp;ComicBook.com",
+      "hash": "afed38607a6deffa"
+    },
+    {
+      "competitor_id": "fubo",
+      "source_label": "fubo_news",
+      "title": "Here\u2019s where FuboTV customers can watch NBA All-Star weekend festivities for FREE amid the NBC blackout - NJ.com",
+      "url": "https://news.google.com/rss/articles/CBMi0wFBVV95cUxQVWtJTG40Nzc1dGhBSnU5eElUb1h2X2tNRGpzSW1YZ25vMVhJT3NoWTA0cEltQXhJZ0JnaFhnZEFtZHJIS1FyNWcxUFV0S2NYa0tfX3lyMzZXWDVRaF80RmtCM0VOSXk3MkVpNzBtWG5Ed0hKWkw5bkk1eFpINGRKUlpjMVU3XzQ2cTZOenM2RlFLdEtveE5vTWZMeTZONE9OcDNBY09aWnZ1bXVJWTBVWm9fNC1HUEt6NG9MVUNteFF2LTAwbEZJLXlERTdnZEtsSGZj0gHnAUFVX3lxTE9CZ3hhek5Ub0tOWDFGdElfUlg1MDdnNXR2bzk5bE5kUXlhYU9ReTBEblFOZWtIYTdHSjhfVTA2dHBkN2tJLTEwZmVmUUI1UzA1X0ZYdGE2UnUzTTBJeXY1Sks0cVZJbnROYmNQYWtESGFleWwyOUVFSklfSUFCXy1EUmdjSlo2bUNfZ2hoYXo0RWtfbFhSRVlLN0FGd2NaRWR2a0VUS2RxZWFsU0hxSXFIMXR3ZFY3Mnd2a1ljNXVqbzBxMXJUb185VUl1VlFqMGJ2Y0tBN1FvYTdVdHdwOXhudGJvTFdJZw?oc=5",
+      "published_at": "2026-02-14T17:00:00",
+      "snippet": "Here\u2019s where FuboTV customers can watch NBA All-Star weekend festivities for FREE amid the NBC blackout&nbsp;&nbsp;NJ.com",
+      "hash": "734355da9a5c85ab"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "the_verge",
+      "title": "iBuyPower\u2019s gaming desktops are discounted for Presidents Day",
+      "url": "https://www.theverge.com/gadgets/878927/ibuypower-gaming-desktop-pc-presidents-day-sale-deal",
+      "published_at": "2026-02-14T17:00:00",
+      "snippet": "Buying a pre-assembled gaming desktop makes sense for some. It can save you time and money, too, compared to buying PC components piecemeal. If you\u2019re weighing your options, consider some Presidents Day offers on iBuyPower\u2019s pre-built desktops, including the $1,899 RDY Element 9 Pro R07 and the $2,099.99 Slate \u2014 both of which are stocked [&#8230;]",
+      "hash": "d13e15d47968a32c"
+    },
+    {
+      "competitor_id": "youtube_tv",
+      "source_label": "youtube_tv_sports",
+      "title": "YouTube TV makes a major change that could save customers money - AL.com",
+      "url": "https://news.google.com/rss/articles/CBMiogFBVV95cUxPZG1ONU1WSEQ1dGdJUEl5ZnE2dEpNaHIzMHNKRWRwUzBRYTlZNVJVN0ZrSmtnZVJMQy15Z2JCRDRpYlZkUTVhRTBnajNyZ2xvWGhNdnhZYUNaRjY5N2haQ3FucXJGa0w1TmJZdWk4NHFWUmxzbzJfOF9hVjBuZ1M2bFZDRXo2dHZpN2l6OHJQLUVPY2plQXdPbjhBQjJzNHhMSUHSAbYBQVVfeXFMTkdVc0FIMFZCbTlYVHhiRnN4R1F1d3I5VlI3bTdVMktsZ3RWbTNvb0ZWak0zY25Bdk5iZ01qSjZjVDQ5aW1ocXpoM0hnV3VWSkxLem4wUHRuUGhaMFBIRDNCWFBoRDRfNjFudXFmbjJaYXpmNUZKOWlMNUFpX2ZGc191dHgzZWZWT2Rza2xZeVprVUtPUmYzSnAxUjJTNFBfbTNVOTZYeFFYY1VpTjZRZmRhaEpUM2c?oc=5",
+      "published_at": "2026-02-14T14:00:00",
+      "snippet": "YouTube TV makes a major change that could save customers money&nbsp;&nbsp;AL.com",
+      "hash": "fb9d77f7e983e9c1"
+    },
+    {
+      "competitor_id": "youtube_tv",
+      "source_label": "youtube_tv_news",
+      "title": "YouTube TV's cheaper bundles, Windows 11 25H2, Discord's bad update, and more: News roundup - How-To Geek",
+      "url": "https://news.google.com/rss/articles/CBMisAFBVV95cUxPUF84N0Zmd1Y0TGZ1NFBPajJyX2owZElDU1dsWG55cHV1MjNSNlNjaGdncUxvTWlEcnotTWJDQUdybUhFd25WY24ycjFFekxNWHZvUkFUT0l5Y2ZKcGdYbHRmZ0Jiall4eGloel9MRDJNeml1aU01X0hFMGtHOEI3emhVV2ZzQ041YXpxeDY4MEROTi01RDRWQVJyaVd0dUoxODAyVjFsUDN4ZEk0aGphcw?oc=5",
+      "published_at": "2026-02-14T13:15:16",
+      "snippet": "YouTube TV's cheaper bundles, Windows 11 25H2, Discord's bad update, and more: News roundup&nbsp;&nbsp;How-To Geek",
+      "hash": "96e588c0a514a9e1"
+    },
+    {
+      "competitor_id": "tubi",
+      "source_label": "tubi_google_news",
+      "title": "Get Tender With Tubi: 14 Best Romantic Movies Streaming Free for Valentine\u2019s Day 2026 - Decider",
+      "url": "https://news.google.com/rss/articles/CBMiZ0FVX3lxTE1lQnZNNkpqNDJFSzJKZUJWelVDZHdGRW1udzNjaE4xOGlJQXQ2SkFubjN5MWZQVGUtZHNRb1JhZ3JEbWExX1VSVWhhNlFoNmswbEZENVhIWklHTVc3WlRyVHBSUi1aUFE?oc=5",
+      "published_at": "2026-02-14T13:00:00",
+      "snippet": "Get Tender With Tubi: 14 Best Romantic Movies Streaming Free for Valentine\u2019s Day 2026&nbsp;&nbsp;Decider",
+      "hash": "769a0caad9a43d26"
+    },
+    {
+      "competitor_id": "fubo",
+      "source_label": "fubo_news",
+      "title": "YouTube TV vs. DIRECTV vs. Fubo: Cheaper Sports Package Breakdown Pricing, Channels & More - | Cord Cutters News",
+      "url": "https://news.google.com/rss/articles/CBMiswFBVV95cUxQQ1NKbGJuVFlaNlFDTDdCREY5d19aekdpc09aMlRGcDN4b0E2XzFNRGdUandERXh4bnpLUWFxU1JTakN0bEdVYWw0aWVBQ29uOGJXaFkteFpxcGw0QVhhZnlpaFh1SzJEbk1CNXdtbVBfbG1wZXFFdk5wNjVzd2l2UnlidDlzS2otZXdneGRYVnBiTm1ZUF80b2lyQW1mYzRnUngzbjU3ZmpoN0YxR3VZWTdZNNIBuwFBVV95cUxOcUduYTQ2VTNKM3dSMDZqY0VNU0lxRzZUWHdxOXAteF9CWk9ZZDhWSUR3d2tjOWpSZHg3UFA1aHo3MG10aGtCM29qLS1sbzhDWmN4OFl2ODFjdVhkYks2emw1UWhCS2dkRGJxZDJwOGdnWjllajBfbnFUQ0Z0MU1QTHc3bm9JN1RkX0dVMU0xcE9yUmY1dlA0SkdQMWJqYU9TcEdaVG96VmxKeTJIV1FOc1ZQaXB5c05Idjg4?oc=5",
+      "published_at": "2026-02-14T12:49:25",
+      "snippet": "YouTube TV vs. DIRECTV vs. Fubo: Cheaper Sports Package Breakdown Pricing, Channels & More&nbsp;&nbsp;| Cord Cutters News",
+      "hash": "97ccc5d6366aad94"
+    },
+    {
+      "competitor_id": "plex",
+      "source_label": "plex_news",
+      "title": "The best free streaming services to watch movies and shows for $0 - Tom's Guide",
+      "url": "https://news.google.com/rss/articles/CBMic0FVX3lxTE9JbVVhRmpEdFdqem9Hc1lQa0NsRDB4Vm5adms2bnVOMmR3T1E0MWhUWXMxSGRUeC1pbU1sOEI4MXRHZ0RrWTliOUNOOUpFckwwRnE4QlBycXZPUFFnWjNiY1FycFdIcU5pbE5ORl9PejNkb1E?oc=5",
+      "published_at": "2026-02-14T06:01:19",
+      "snippet": "The best free streaming services to watch movies and shows for $0&nbsp;&nbsp;Tom's Guide",
+      "hash": "72fd0e6c97188ca0"
+    },
+    {
+      "competitor_id": "vizio_watchfree",
+      "source_label": "walmart_vizio",
+      "title": "Roku exploring other retail partnerships after Walmart buys Vizio, CEO says - TheDesk.net",
+      "url": "https://news.google.com/rss/articles/CBMiakFVX3lxTE0zaUV3c2o3QWZ2RFRFMkxpN0NLVW5Sdy1xaGRfRU03NDQ4VWdZYkJtcmh1dnpBUDVjWTNadTd4VC0yMm9hRHBSNXRIdGVES3UtWWZ6c3YzRnBWcmhQcF9YMVFOc09YZ3ZtTXc?oc=5",
+      "published_at": "2026-02-14T02:40:46",
+      "snippet": "Roku exploring other retail partnerships after Walmart buys Vizio, CEO says&nbsp;&nbsp;TheDesk.net",
+      "hash": "9156b8bd2dd5ec1f"
+    },
+    {
+      "competitor_id": "roku_channel",
+      "source_label": "roku_news",
+      "title": "Roku just got 9 new free streaming channels \u2014 including Pok\u00e9mon and a bunch of TV classics from the 90s and 00s - TechRadar",
+      "url": "https://news.google.com/rss/articles/CBMilgJBVV95cUxOVUFEdTNJMUZnc1pXQUxaaVlEWlBhUUh5YjFPVlhQb0h6cmFXSGtRZkZkaXV4Ni1tejI2UFpVVDNjd2lUY3hkT3luVDVKNGs4V1JkSG4wRTBESXpoT2dtSUNLVU9pdWQxUkdvWVY1SVFCaHEwYUl4WHJ3UTVSMkJjUE1YbFNzbzRwbWV3U3RCX2lQNDRiX29XUDZCYjA4V2hpbm9jdHJpTDRfOGxqbjhFeWRzVjhQTXVYUVlFSHBfV3FHRzFUR2VHZUU0V2xmNTRlNEExWktQeThfclhKa0hSbVpNcEJFVjVuV0d2ZHRmcE9oMkpyNlJ4eElkZHRLMXJaazJ3dXZVZFRrMmR6S3RiTmlja0FMUQ?oc=5",
+      "published_at": "2026-02-13T22:36:40",
+      "snippet": "Roku just got 9 new free streaming channels \u2014 including Pok\u00e9mon and a bunch of TV classics from the 90s and 00s&nbsp;&nbsp;TechRadar",
+      "hash": "dd95407652086c92"
+    },
+    {
+      "competitor_id": "fubo",
+      "source_label": "fubo_news",
+      "title": "Where to watch WWE Smackdown tonight in Dallas on free streams and TV during NBC and Fubo dispute - PennLive.com",
+      "url": "https://news.google.com/rss/articles/CBMi1AFBVV95cUxOdlEtUWVRazRUSTRaY1ZWU1JGczBBZ3FhcUdKYXg5ckxmc2E2MDJKczlzY01LdVdwRjlzN2VPRDdqNEEtTWxONTZIWF9SU2FGQ0czaGhWWllPaXBwZXJzU1ltUDFCQkw4SVhfck1pb1dsQ3hJcjJPS3p3UzUzS20xNU9IYVQ5VDBvd1lsNUVYTU9kUjJjTjNYcU9vUTZ0UF96Z1QzZnV1RnJjR1Y0QkVnZ0VGb3Z0WGl3ZmpGVlhXSU9tbHYtQlQ4ZEV0YVNpX0MzUk9Wb9IB6AFBVV95cUxPa0xyVVNJV1pvNDZUcHFadWJ1Y1NnMi1BZFJSTjRKcnc3ekFlUFNCVG9HaHpWTzVTVEVjaXpiNGl4UTNpSXZyOG9VaVQ5X2xvZDNPdVRnTzZQZmJndnN6YjdER29tM0YyRDhWZFpFR1h6M1EyQ2tZUFBCSUJjamhlR0JCd3Q2OTJ2bVhPaDJIUVZ2clZsb0VKQTdSZGlQVTVfaHFVcGl1WU5VaXlkNVJmcVQxdm9zaXlTR2FCcllWOGNlVmdOTFFXeFI4cjhpeVI2TDBOakxRb1U3ekY5clJVWVVxREhEVGRO?oc=5",
+      "published_at": "2026-02-13T21:29:00",
+      "snippet": "Where to watch WWE Smackdown tonight in Dallas on free streams and TV during NBC and Fubo dispute&nbsp;&nbsp;PennLive.com",
+      "hash": "3899b924381ff052"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "variety_streaming",
+      "title": "Mattel to Acquire Full Ownership of Mattel163 From NetEase (Gaming News Roundup)",
+      "url": "https://variety.com/2026/gaming/news/mattel-163-gaming-news-roundup-1236658843/",
+      "published_at": "2026-02-13T21:23:00",
+      "snippet": "Mattel, Inc, in agreement with its joint venture partner NetEase, has announced it will acquire full ownership of the Mattel163 mobile games studio. The transaction is expected to be completed by the end of Q1.&#160; Founded in 2018, Mattel163, a global game studio, has developed games based on iconic Mattel brands including Uno!, Uno Wonder, [&#8230;]",
+      "hash": "d31ffd0f978ed86e"
+    },
+    {
+      "competitor_id": "hulu_live",
+      "source_label": "hulu_live_news",
+      "title": "YouTube TV vs. Fubo vs. Hulu Live vs. Sling and More: 100 Top Live TV Streaming Channels Compared - CNET",
+      "url": "https://news.google.com/rss/articles/CBMiwwFBVV95cUxNZ1hTQ1Q2OV9qbTZ4ME8zTDhZMHJRNFV3TnZFYmtXdjAyYzBIVjRlUGxVYzRFUzljenRfd1lnWkp4SEZZSVJ0WWtXV0NFV01XQXVndnBsWnBab2tmLU1IajY2YmVJM3doeFZibDhiTVo0TFdVUjNOc2xPS04zOW83czA4WndmaGxkZkFhZ0hFLWRMbEVkNWxzZHF5bWxGUkpGZTRuMllBc0pVRVplTmoyNHAtb0VQd0haZVUtYlUyUm1OdGM?oc=5",
+      "published_at": "2026-02-13T21:01:00",
+      "snippet": "YouTube TV vs. Fubo vs. Hulu Live vs. Sling and More: 100 Top Live TV Streaming Channels Compared&nbsp;&nbsp;CNET",
+      "hash": "881b4e00588dcba4"
+    },
+    {
+      "competitor_id": "fubo",
+      "source_label": "fubo_news",
+      "title": "How to watch Ohio State wrestling vs Penn State: Time, TV, streaming - Buckeyes Wire",
+      "url": "https://news.google.com/rss/articles/CBMi5gFBVV95cUxNZGhGam0ya1Zsd215SU5iTkpVQzNrSUQxbjdncjZFNFFaaElVdUxPOXZpSk1Eam05Tm4wQXhMZEFyaHMxS2RsTFUwalNfVXVwWkJURzNDSkY0ZmRMTm5mWmdmUGpSbDNpMTladlhOTFlMa0dPVjJMQTBqbmVVU29fUUlmSWVab25uNFZzcnF2NndyTGw1Ny0tWlQwVVF1Sm9HVnJzTC0xb2tQUTlPcGl2Mzk3YWNvQ1RYTDVmTzdFY2JJeFlkLUNLbWJLZmxtSl9YUnhZcU5kaXlmWXZmUC13VHlFOThHZw?oc=5",
+      "published_at": "2026-02-13T20:43:00",
+      "snippet": "How to watch Ohio State wrestling vs Penn State: Time, TV, streaming&nbsp;&nbsp;Buckeyes Wire",
+      "hash": "89d562c692a8fbdb"
+    },
+    {
+      "competitor_id": "youtube_tv",
+      "source_label": "youtube_tv_sports",
+      "title": "YouTube TV will soon offer cheaper bundles, including a new sports plan - Mashable",
+      "url": "https://news.google.com/rss/articles/CBMiqAFBVV95cUxQaElIMzFfQTliRUdIdWlORjU5XzlUd3kzZU9Oam11QWJENEdoNmZqMm9Gc2V3TDRuV1Zpa2pXV3VqcDZySENZZUVweXJKOEp0TU9WLUYtWG1lSHBXZjVVelFGb3NicmlOcDAwb2pJc0VvSlgxTWh4MkRWRzZnT1p6b2dkLXVvM1UwVlRILVlkdjN0bnpwTmFqb0NCeVVuUXNBYjVTVTBodUE?oc=5",
+      "published_at": "2026-02-13T20:17:35",
+      "snippet": "YouTube TV will soon offer cheaper bundles, including a new sports plan&nbsp;&nbsp;Mashable",
+      "hash": "883908de7ed093bb"
+    },
+    {
+      "competitor_id": "tubi",
+      "source_label": "tubi_google_news",
+      "title": "\u2018KISSING IS THE EASY PART\u2019: TUBI ADAPTS ANOTHER CHARMING ROMANCE - RissiWrites.com",
+      "url": "https://news.google.com/rss/articles/CBMiiwFBVV95cUxPeERSY0NtUWIwXzg2ZmJJVW9UeGl4TlpkME9jSE1uNXlSRjV5cUhhNlRxeWxLcXRVVUMwTTQ5UThQSTB3SEhfQ3Y0TERIc1I4NUp6WGwzU2syaUtocEJ5MHc2ZjUxZG1CbVpwWmI3WGdoZHVVaC1oX1cteWloTVFNVWpoU3cxUUI1clkw?oc=5",
+      "published_at": "2026-02-13T19:52:00",
+      "snippet": "\u2018KISSING IS THE EASY PART\u2019: TUBI ADAPTS ANOTHER CHARMING ROMANCE&nbsp;&nbsp;RissiWrites.com",
+      "hash": "4a61ad8c215d6a3c"
+    },
+    {
+      "competitor_id": "fubo",
+      "source_label": "fubo_news",
+      "title": "How to Stream Every MLB Game in 2026 - Fubo",
+      "url": "https://news.google.com/rss/articles/CBMidEFVX3lxTE53amlTX2FIMUI3MXRmVnREdnRoa0tpLWJ2dVBvTlZMQ0NwRFVXYVN4RXNWbzBsNHhRUldzeDNPX3J5aGVRWGY3TlFJQmR4eXBjY0N1VUFUaDEtSF9Jb2JuUjJ6WHNPN3pzSEp6SFRMelJBMGtz?oc=5",
+      "published_at": "2026-02-13T19:22:48",
+      "snippet": "How to Stream Every MLB Game in 2026&nbsp;&nbsp;Fubo",
+      "hash": "a0903a1903b97126"
+    },
+    {
+      "competitor_id": "roku_channel",
+      "source_label": "roku_news",
+      "title": "If you haven't tried these useful Roku audio features, you're missing out - Pocket-lint",
+      "url": "https://news.google.com/rss/articles/CBMiZkFVX3lxTE5UemI1eGZaOTN1Z3diQWQ1UHFENElPWXJocTh2Qks5QkxEQXh4ZFlQakQxLTRLZ01sY0k4NnUtOVJIUTB1SHBkNnhKNmlkUjR4OHduMzNlSVBUZmZheElRNl8zanA2Zw?oc=5",
+      "published_at": "2026-02-13T19:08:42",
+      "snippet": "If you haven't tried these useful Roku audio features, you're missing out&nbsp;&nbsp;Pocket-lint",
+      "hash": "d09b8193a5a4057f"
+    },
+    {
+      "competitor_id": "tubi",
+      "source_label": "tubi_fox",
+      "title": "How to Watch the 2026 World Baseball Classic on FOX, FS1 and Tubi - World Baseball Network",
+      "url": "https://news.google.com/rss/articles/CBMilgFBVV95cUxQZlJOU1dWZENoSGhoVXd4SDNpeEg4bWRHTHBiVEpGQnpoNGhiX0g2b1kyQUJFUjhiVF9nNFQzaUlRSkRIUG9CbGpJTUVUeGlDWUZPX0xWV3NsbFowS3NJTFpmSWw4ZXdQWWFWcjlDU193NjcyRjlrSG43TWk5WjRuV2tTcndMZW9qWVhmVGFQOG03RGZkSlE?oc=5",
+      "published_at": "2026-02-13T18:36:45",
+      "snippet": "How to Watch the 2026 World Baseball Classic on FOX, FS1 and Tubi&nbsp;&nbsp;World Baseball Network",
+      "hash": "8368899094ba8db0"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "ctv_advertising",
+      "title": "Cineverse Acquires TV Monetization Platform IndiCue - TVTechnology",
+      "url": "https://news.google.com/rss/articles/CBMioAFBVV95cUxNUGs4MHVocHRyZmVhbV96ek5pMDhIVnFDTl94M1k0Y3oxYjRaMjFMcjltZmNiSFpIUWNxQ0JULVpOSTB3Z1YyTld1Tm50c2NQY25KRjBNR1JFTzBZU2Vvc3BQaWc4c0o5S0ZIQy1TVGdkZjdaX1phbmhJM0RrOEN4YzVrNHR2SWVmWmRadGcyWE1YdGlCZFd6akRJYWdhV1F5?oc=5",
+      "published_at": "2026-02-13T18:02:45",
+      "snippet": "Cineverse Acquires TV Monetization Platform IndiCue&nbsp;&nbsp;TVTechnology",
+      "hash": "26ff511dd2d7808d"
+    },
+    {
+      "competitor_id": "samsung_tv_plus",
+      "source_label": "samsung_tv_plus_news",
+      "title": "Samsung TV Plus in New FAST Partnership With Major League Volleyball - Media Play News",
+      "url": "https://news.google.com/rss/articles/CBMioAFBVV95cUxNSG0xblZyM0RkVjVqYXFZcHo0ZmZpbS1Gb3hfYlQ3Y0ZSQ3EyV2c4NUExb1d2Z0VndDc3TmoyN2NmSUNHcWE1LUtFdWk5SlNCdlhxTFlLTm1WeUV6N2hkSEs5b3ViYzJlMk1KVE16Ty1FamNkbjlSSzRfbG53V3dxc2JaVEpWMFVIMmhMeVIxQWV0MGJJN3NLUEtnNl9ZUFZk?oc=5",
+      "published_at": "2026-02-13T17:27:23",
+      "snippet": "Samsung TV Plus in New FAST Partnership With Major League Volleyball&nbsp;&nbsp;Media Play News",
+      "hash": "572eaaa397c41981"
+    },
+    {
+      "competitor_id": "amazon_fire_tv",
+      "source_label": "amazon_fire_tv_news",
+      "title": "10 incredible Fire TV Stick apps you've probably never heard of - Android Police",
+      "url": "https://news.google.com/rss/articles/CBMilAFBVV95cUxNVTl5N2NTV1hYQmhQOHBnejB0TWQ5VmhTSC1pd1hkTWQtaFIyZ0NrU20zRVhYdWxkNFc5ejk2bE03ajZiWnMyaXlEVEZWdXpWLUlmYkdFVVJOelh0MTR6YnFFSGhjRlJQQ2cxV0JIWEVXUkh3SWdfc0dMMmV2c1RJR2hSMGc5cVhPNVVqT2hEM3BJd3BW?oc=5",
+      "published_at": "2026-02-13T17:15:10",
+      "snippet": "10 incredible Fire TV Stick apps you've probably never heard of&nbsp;&nbsp;Android Police",
+      "hash": "87ec29bf8262d038"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "digiday",
+      "title": "How a precise timing structure drives material differences in marketing efficiency",
+      "url": "https://digiday.com/sponsored/how-a-precise-timing-structure-drives-material-differences-in-marketing-efficiency/?utm_campaign=digidaydis&utm_medium=rss&utm_source=general-rss",
+      "published_at": "2026-02-13T16:56:30",
+      "snippet": "Jesse Math, vp of strategic partnerships, Keen Decision Systems The marketing calendar itself is simple. Brands need to invest in the typical tentpole events like Prime Day, back-to-school and the holidays. They also have their own key sales periods, like the beginning of the winter season for a company that makes jackets or for a [&#8230;]",
+      "hash": "f6836687b95e707f"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "variety_streaming",
+      "title": "New Funko CEO on Cornering \u2018Kidult\u2019 Collectibles Market in a Rough Economy: \u2018There\u2019s Almost More Value for Something That\u2019s Physical and Tangible\u2019",
+      "url": "https://variety.com/2026/tv/news/funko-new-york-toy-fair-reveals-ceo-josh-simon-1236659544/",
+      "published_at": "2026-02-13T16:19:08",
+      "snippet": "If you work in entertainment, you&#8217;ve definitely seen a Funko Pop figure. The modern, more sophisticated versions of bobble-head toys are among the first consumer products that an IP secures a deal for if it wants to engage a proper fandom. From Star Wars to &#8220;KPop Demon Hunters&#8221; to European football teams, if you&#8217;re a [&#8230;]",
+      "hash": "f55147e40097329e"
+    },
+    {
+      "competitor_id": "peacock",
+      "source_label": "peacock_news",
+      "title": "How to Watch the 2026 NBA All-Star Game \"U.S. vs World\" on NBC & Peacock - NBC",
+      "url": "https://news.google.com/rss/articles/CBMijwFBVV95cUxPLVEyMkd1cGZ1QXlYWXV2MlFHb1hqSUE0N0RIMWdYR2Q4MnZqNnFsN0Rjd0ZhVDdKWHlWVjJIY2xHeUJSQ3VQTllTWExZNmp5UWJoMVEydmlzSUU4Y1R1UFppRjZtVG92ZURGUEsyYTU1am5wSnZ3MlNxRkZpWHVPbkl2VHBqWTdjUG4xekJtMA?oc=5",
+      "published_at": "2026-02-13T16:14:54",
+      "snippet": "How to Watch the 2026 NBA All-Star Game \"U.S. vs World\" on NBC & Peacock&nbsp;&nbsp;NBC",
+      "hash": "70311a66d68f5018"
+    },
+    {
+      "competitor_id": "tubi",
+      "source_label": "tubi_google_news",
+      "title": "HBO Max Animated Fan-Favorites Find New Streaming Home - ComicBook.com",
+      "url": "https://news.google.com/rss/articles/CBMikgFBVV95cUxOdTJrNmVnTlYxeUJhZFpIenRCTWpUV0xlT01RSnNPODNnQjBmUS10LTFpN0FLNmZDMk9FYkRBV3BpRGQwN0Vtb1dNVlV1ZzNKQlJzMTdQVktTUXhLQ0FOQU5Oa0pPVmtWajVzUy1QZG1jcnEyVFpTdzRPZlNLVGNvNDZKbEZzSFd3RVJVT2VZNEtnUQ?oc=5",
+      "published_at": "2026-02-13T15:39:30",
+      "snippet": "HBO Max Animated Fan-Favorites Find New Streaming Home&nbsp;&nbsp;ComicBook.com",
+      "hash": "210b1b066857b0b2"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "variety_streaming",
+      "title": "Nexo Studios Launches Sales at EFM on Doc About First Millennial Saint Carlo Acutis, Dubbed \u2018God\u2019s Influencer\u2019",
+      "url": "https://variety.com/2026/digital/global/nexo-digital-efm-first-millennial-saint-carlo-acutis-1236662212/",
+      "published_at": "2026-02-13T15:09:53",
+      "snippet": "Italy\u2019s Nexo Studios, which produces and distributes theatrical event content for the global market, is launching sales at Berlin\u2019s European Film Market on high-profile doc \u201cCarlo Acutis \u2013 The Millennial Saint\u201d about the 15-year-old who in 2025 become the Roman Catholic Church\u2019s first millennial saint. Carlo Acutis, who died of leukemia on Oct. 12, 2006, [&#8230;]",
+      "hash": "8a95afa16874127a"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "adweek",
+      "title": "Inside the NBA&#8217;s Strategy for Big Brand Plays During All-Star Weekend",
+      "url": "https://www.adweek.com/convergent-tv/nba-brands-all-star-weekend-2026/",
+      "published_at": "2026-02-13T15:07:10",
+      "snippet": "The NBA's svp of marketing partnerships reveals how brands such as Google, DoorDash, and Amex are showing up at All-Star.",
+      "hash": "1347adbd3a59cf58"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "adweek",
+      "title": "Streaming Ratings, Week of Jan. 12: His &amp; Hers Lands at the Top of the Chart",
+      "url": "https://www.adweek.com/convergent-tv/streaming-ratings-week-of-january-12-2026/",
+      "published_at": "2026-02-13T14:43:58",
+      "snippet": "The top five titles had over a billion viewing minutes.",
+      "hash": "4b5207dfa2598a48"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "variety_streaming",
+      "title": "Amazon\u2019s Ring Scraps Police-Notification Partnership After Backlash Over Super Bowl Ad About AI-Enabled Dog Finder",
+      "url": "https://variety.com/2026/digital/news/amazon-ring-cancels-flock-partnership-super-bowl-ad-backlash-dog-finder-1236662108/",
+      "published_at": "2026-02-13T13:51:38",
+      "snippet": "Ring, the Amazon home-security division, ran one of the most-liked ads during Super Bowl LX: a spot promoting Search Party, a feature that helps people find lost dogs using AI to scan opt-in footage from Ring cameras in a neighborhood. Many viewers found Ring&#8217;s Search Party canine-finding ad heartwarming. Others, however, were alarmed at the [&#8230;]",
+      "hash": "91eaa382c51cb1ac"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "variety_streaming",
+      "title": "Prime Video Drops Italian Original Film \u2018Love Me Love Me\u2019 Based on Wattpad  Book That \u2018Garnered\u00a0 24 Million Reads,\u2019 Producers Discuss YA Romance Trend (EXCLUSIVE)",
+      "url": "https://variety.com/2026/digital/global/prime-video-original-love-me-love-wattpad-ya-romance-1236659353/",
+      "published_at": "2026-02-13T12:57:32",
+      "snippet": "Prime Video on Friday released its first English-language Italian original &#8220;Love Me Love Me, based on the first novel from a four-book series by Italian writer Stefania S, which has scored 24 million reads globally on the Wattpad platform. It will be interesting to see if &#8220;Love Me Love Me&#8221; becomes a hot Italian TV [&#8230;]",
+      "hash": "5e050a4831f12f47"
+    },
+    {
+      "competitor_id": "youtube_tv",
+      "source_label": "youtube_tv_sports",
+      "title": "YouTube TV Announces All The Channels Coming to Its Cheaper TV Packages, Including Its Sports Package - | Cord Cutters News",
+      "url": "https://news.google.com/rss/articles/CBMiyAFBVV95cUxOYTdoRnZHZW9rTW5sQ1RxUVBJWTZLQ2FnU2Jjd1M3YWZuem9ZT1d5RWlnc1ZhME80SEFxc2hkenlaZ09iQzF4LXBfTm1GNS12NWxQMGd4elBqUHBlbzRXbjFna2kybkZac19DOF8tVjVlMWwzenpfc2VIWXZDbW5oUmwyd2tVX3M0RFRNNGRwOWhpbzFqQVVaUVFnYUJGVVRnVXc5ZGc0ZmQ2M0dmSDNiSzBoeGFGNXBjTWRvODVJUjIxTmQxS1VHRtIB0AFBVV95cUxOUXRpa1pvN0s4VldyYVdzUFR1NXpwZWxFN1FQc0RlTGMwanJrR2w3dmlraG9TZTViY3R6a3JDNmZwa2lNT0hRc0hnWGdxN1VCanBsX2FvbWNxdFU1dHdncnBYX0ZuSjVJcDRMNmg5UklNb1Z4UVV6TEl1ZVZIS3ZCUENoOWZOOVdIZVdQb1hxY0k3anFEQ2xhckFENHV4bG5VXzJINHNVc0Z5dndLR1ppTEdSdldNdHdMM01lLVVPQW9lampHdkw0NGF2MHZ0bXVh?oc=5",
+      "published_at": "2026-02-13T12:45:54",
+      "snippet": "YouTube TV Announces All The Channels Coming to Its Cheaper TV Packages, Including Its Sports Package&nbsp;&nbsp;| Cord Cutters News",
+      "hash": "93b740d3035a59e9"
+    },
+    {
+      "competitor_id": "fubo",
+      "source_label": "fubo_news",
+      "title": "fuboTV Inc. (FUBO) in Focus: Earnings Momentum and Investor Moves - Insider Monkey",
+      "url": "https://news.google.com/rss/articles/CBMiqAFBVV95cUxPdTg2aFBlOHRfRHhSMWU2SS1zR0l4QWU4WE8tQzlSOXNoVnZ1QTU3T0xvVWh4YkswajlGby15bUw5Ni1Qa0Ytdnl3WGZzOEpiZzN1VFl1djVQejkyWFJzM1ZZbms5STR6SmU2T3RzS2c4T292MGFVUnI1alFQUlE5Ui1IVFpCTGdLaDQydmlESXRORDJLR3BGeUVKUFZCSUNxVnRZVk4wQk7SAbABQVVfeXFMUE1jajNRdUxIT3NRMEtDQnQwbnU4OVBrZGZmSXRWajhDMU1iTE9QX2hwb0l0WDlIZ0J4NTJ2VFd5U3N1SVZYZXk4YVliWDhlWHd4V3RDVWswV2FkQWozMmdsdV9Hekw0YzBuTHZfbm53ai1vMW1wSlVMVk9fTXBMNWRhbG1EcDNpdEZ2eTM5dGQyTnc1S2tFR1JVSGFGSGNWR2s1NHc2V3c3dUdidTNmYTY?oc=5",
+      "published_at": "2026-02-13T12:20:46",
+      "snippet": "fuboTV Inc. (FUBO) in Focus: Earnings Momentum and Investor Moves&nbsp;&nbsp;Insider Monkey",
+      "hash": "b9ebe9e0196e7dc1"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "adweek",
+      "title": "5 Questions For\u2026Reporters in Arizona Covering Nancy Guthrie\u2019s Disappearance",
+      "url": "https://www.adweek.com/tvnewser/5-questions-for-reporters-covering-nancy-guthries-disappearance/",
+      "published_at": "2026-02-13T11:51:18",
+      "snippet": "CNN\u2019s Ed Lavandera and NewsNation\u2019s Brian Entin share their perspective on a story directly affecting one of their own.",
+      "hash": "861ca84ecd914977"
+    },
+    {
+      "competitor_id": "samsung_tv_plus",
+      "source_label": "samsung_tv_plus_news",
+      "title": "Samsung\u2019s free TV platform reaches 100 million users - Sammy Fans",
+      "url": "https://news.google.com/rss/articles/CBMilwFBVV95cUxNbzJVQlNTSVcwQ1J2NmRCcEFJbVlHcjI1aE4zelEwS21pUVV5QlMxRTIzYjlxVDVGYTRwcExGbkx1R3kwUGFnZHhYVWtWOUozd1ZqbG96TmFsX0YwWEpLYzg2VGVSYk5fYXh2eEZvY3pLV1FRN0VhTDIzM1d0c0F3MlBHS1YwbmluMWpNVUk1QWNWT0IxVGFB0gGXAUFVX3lxTE1vMlVCU1NJVzBDUnY2ZEJwQUltWUdyMjVoTjN6UTBLbWlRVXlCUzFFMjNiOXFUNUZhNHBwTEZuTHVHeTBQYWdkeFhVa1Y5SjN3Vmpsb3pOYWxfRjBYSktjODZUZVJiTl9heHZ4Rm9jektXUVE3RWFMMjMzV3RzQXcyUEdLVjBuaW4xak1VSTVBY1ZPQjFUYUE?oc=5",
+      "published_at": "2026-02-13T10:28:40",
+      "snippet": "Samsung\u2019s free TV platform reaches 100 million users&nbsp;&nbsp;Sammy Fans",
+      "hash": "8ca96cf1285f1f8a"
+    },
+    {
+      "competitor_id": "fubo",
+      "source_label": "fubo_news",
+      "title": "Fubo Review: Pricing, plans, subscriptions, free trials and more - Goal.com",
+      "url": "https://news.google.com/rss/articles/CBMitAFBVV95cUxNYzNSN2xWaEl6d210US1ZaEV3azFTRmFyM2xsNW5tUU5rVGRsNmZtWl8zbFJqYlExVnd1TUFxUlYxYnVrSU4tcFVqVXFvMlN4QncxRU50NWRqZ0lFU3VYZm96LV9OSlo1TUlxUGNaTEhtU0VIRzl3ZlhJajQzMFNzSFFBZVBGYW1kak42d2lydzFmS1llRVo4UGtfVnZhR25WaUhRZjBMSUdhbUxiZDRESEdUdXY?oc=5",
+      "published_at": "2026-02-13T10:00:00",
+      "snippet": "Fubo Review: Pricing, plans, subscriptions, free trials and more&nbsp;&nbsp;Goal.com",
+      "hash": "e9c9bcf421a32edd"
+    },
+    {
+      "competitor_id": "roku_channel",
+      "source_label": "roku_news",
+      "title": "Roku FY revenue up 15% - Advanced Television",
+      "url": "https://news.google.com/rss/articles/CBMieEFVX3lxTE5FS3NtMnUxcVJqN1ViS2pYT3dzVkVNcDgyTURmb3g0U3lYUDdVVkVGMDdac1FUaDZRdkFJVlV1UGNlTFpLWGRUbXpYLXQ0TUxGOGJ1dGswdU9lcEtwLU5KbFA3RmZqMGpTQm9RX1AySEJVV3dkUDZVNA?oc=5",
+      "published_at": "2026-02-13T09:56:54",
+      "snippet": "Roku FY revenue up 15%&nbsp;&nbsp;Advanced Television",
+      "hash": "72465a2935da09c8"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "adweek",
+      "title": "Dentsu Overhauls Leadership, Names Takeshi Sano CEO",
+      "url": "https://www.adweek.com/agencies/dentsu-overhauls-leadership-names-takeshi-sano-ceo/",
+      "published_at": "2026-02-13T09:11:27",
+      "snippet": "The company installs its Japan chief to revive its struggling overseas business",
+      "hash": "430b39ec477545bd"
+    },
+    {
+      "competitor_id": "samsung_tv_plus",
+      "source_label": "samsung_newsroom",
+      "title": "Samsung Discusses TV Plus Journey After Crossing 100 Million Users - SammyGuru",
+      "url": "https://news.google.com/rss/articles/CBMikwFBVV95cUxPeVJ6V0FraENyZy10U05KQVJva2l3c0J2VUROQ0tlUDFSVHhSQTdJM2JvZEhwTWhJbWxYU20wV0pRMEhvZV9KSEV4cFlHT1FuYXpibFpZV0s3ZG15S1JIOE5zYldYM0FPRkVzcHFrLXJma3hXSHNocXJ0ei00OU9mQTh5eDRrRnpZRjY1RUNJLUxtU2s?oc=5",
+      "published_at": "2026-02-13T08:43:31",
+      "snippet": "Samsung Discusses TV Plus Journey After Crossing 100 Million Users&nbsp;&nbsp;SammyGuru",
+      "hash": "70d3f268d95bd697"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "adweek",
+      "title": "Old Spice Updates \u2018Mom Song\u2019 With a Modern Motherhood Twist",
+      "url": "https://www.adweek.com/creativity/old-spice-updates-mom-song-with-a-modern-motherhood-twist/",
+      "published_at": "2026-02-13T08:30:00",
+      "snippet": "Old Spice reboots its classic 'Man Song' ad with a modern twist.",
+      "hash": "dbf9fe297ba19cb8"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "adweek",
+      "title": "MLS Unites 30 Teams Around &#8216;Fun,&#8217; Not Rivalries, as World Cup Looms",
+      "url": "https://www.adweek.com/creativity/mls-unites-30-teams-around-fun-not-rivalries-as-world-cup-looms/",
+      "published_at": "2026-02-13T07:47:41",
+      "snippet": "MLS brings 30 clubs under a unified message to capitalize on World Cup momentum.",
+      "hash": "cd606dc501084a34"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "adweek",
+      "title": "FanDuel Taps Ari Avishay From Paramount+ as Marketing Leader",
+      "url": "https://www.adweek.com/brand-marketing/fanduel-taps-ari-avishay-from-paramount-as-marketing-leader/",
+      "published_at": "2026-02-13T07:21:47",
+      "snippet": "He also brings experience from Hulu and Lyft.",
+      "hash": "1e8a051dcb384a72"
+    },
+    {
+      "competitor_id": "roku_channel",
+      "source_label": "roku_news",
+      "title": "Roku Expands Free Channels And News Hub As Investors Weigh Ad Growth - simplywall.st",
+      "url": "https://news.google.com/rss/articles/CBMivAFBVV95cUxQTHV6aWMwWEdwVWNBVDl3ekUxRjZlZGV5dEFUSVc3LUR5LWhZMnV3c0JDR1lGVlN5LUVMS0R3OGk2RFJYR3NTckM4NzZldXJYWExiYXFKYTVZYUFlZXJhMkx0ejhsRloyemprcTR4b1JGU3Q4dC1TbEgzQ3NwYU5kN2Y4bmZOc2tLVl84bzN1YzBSUGs0QkFnTnFGS3BxVDNIa05fQ1l4aGlwdGNaYkJva1l5SDd3Szk4VmlNVw?oc=5",
+      "published_at": "2026-02-13T06:37:30",
+      "snippet": "Roku Expands Free Channels And News Hub As Investors Weigh Ad Growth&nbsp;&nbsp;simplywall.st",
+      "hash": "53dcc73be039dee4"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "adweek",
+      "title": "Apple Turns Bad Bunny\u2019s Super Bowl Performance into a Global \u2018Shot on iPhone\u2019 Party",
+      "url": "https://www.adweek.com/creativity/apple-turns-bad-bunnys-super-bowl-performance-into-a-global-shot-on-iphone-party/",
+      "published_at": "2026-02-13T06:26:10",
+      "snippet": "Apple Music captured Bad Bunny\u2019s groundbreaking Super Bowl Halftime Show through the iPhone lenses of fans around the world.",
+      "hash": "c8abc9185cc8213b"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "adweek",
+      "title": "Ads of the Week: 6 Campaigns That Caught Our Eye, From McDonald&#8217;s to DoorDash",
+      "url": "https://www.adweek.com/creativity/ads-of-the-week-6-campaigns-that-caught-our-eye-from-mcdonalds-to-doordash/",
+      "published_at": "2026-02-13T06:00:00",
+      "snippet": "This week's standout campaigns celebrate Valentine's Day with a more modern view of relationships",
+      "hash": "40ed032e3376cd5e"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "digiday",
+      "title": "From feeds to streets: How mega influencer Haley Baylee is diversifying beyond platform algorithms",
+      "url": "https://digiday.com/media/from-feeds-to-streets-how-mega-influencer-haley-baylee-is-diversifying-beyond-platform-algorithms/?utm_campaign=digidaydis&utm_medium=rss&utm_source=general-rss",
+      "published_at": "2026-02-13T05:01:00",
+      "snippet": "Kalil is partnering with LinkNYC to take her social media content into the real world and the streets of NYC.",
+      "hash": "28b83ed6a8e8ae4d"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "digiday",
+      "title": "\u2018A brand trip\u2019: How the creator economy showed up at this year\u2019s Super Bowl",
+      "url": "https://digiday.com/media/a-brand-trip-how-the-creator-economy-showed-up-at-this-years-super-bowl/?utm_campaign=digidaydis&utm_medium=rss&utm_source=general-rss",
+      "published_at": "2026-02-13T05:01:00",
+      "snippet": "Super Bowl 2026 had more on-the-ground brand activations and creator participation than ever, showcasing how it's become a massive IRL moment for the creator economy.",
+      "hash": "d0e487db85686430"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "digiday",
+      "title": "Future of Marketing Briefing: AI\u2019s branding problem is why marketers keep it off the label",
+      "url": "https://digiday.com/marketing/future-of-marketing-briefing-ais-branding-problem-is-why-marketers-keep-it-off-the-label/?utm_campaign=digidaydis&utm_medium=rss&utm_source=general-rss",
+      "published_at": "2026-02-13T05:01:00",
+      "snippet": "The reputational downside is clearer than the branding upside, which makes discretion the safer strategy.",
+      "hash": "3b2487efdebabdec"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "digiday",
+      "title": "While holdcos build \u2018death stars of content,\u2019 indie creative agencies take alternative routes",
+      "url": "https://digiday.com/marketing/while-holdcos-build-death-stars-of-content-indie-creative-agencies-take-alternative-routes/?utm_campaign=digidaydis&utm_medium=rss&utm_source=general-rss",
+      "published_at": "2026-02-13T05:01:00",
+      "snippet": "Indie agencies and the holding company sector were once bound together. The Super Bowl and WPP\u2019s latest remodeling plans show they\u2019re heading in different directions.",
+      "hash": "aa686256492c276e"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "digiday",
+      "title": "How Boll & Branch leverages AI for operational and creative tasks",
+      "url": "https://digiday.com/marketing/how-boll-branch-leverages-ai-for-operational-and-creative-tasks/?utm_campaign=digidaydis&utm_medium=rss&utm_source=general-rss",
+      "published_at": "2026-02-13T05:01:00",
+      "snippet": "Boll &#38; Branch first and foremost uses AI to manage workflows across teams.",
+      "hash": "b157c2c8a4ac746e"
+    },
+    {
+      "competitor_id": "tubi",
+      "source_label": "tubi_fox",
+      "title": "FOX Sports announces complete World Baseball Classic broadcast schedule - WFIN",
+      "url": "https://news.google.com/rss/articles/CBMiogFBVV95cUxPMzJNR09NMWY3UHNmMklLNkl2TVpocHJtTE51TTRFVjlxZ1JRZGRsbkZqQ0ExUGtNV2NWUHlaWVBDSVpTZWZyTTI3UXB0Q1NmSjd2U2ROUFFYdG1YbnFFX0xOZEkyRFB0RTFuQjM2dTY3Sk5nMEtESXFvSGpycDY1ZEZxUV9oalBEbGg3Zko2SEJjNHprUzlwSWhsTUlpdm9aX3c?oc=5",
+      "published_at": "2026-02-13T01:45:38",
+      "snippet": "FOX Sports announces complete World Baseball Classic broadcast schedule&nbsp;&nbsp;WFIN",
+      "hash": "cf1808d42aefd1df"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "variety_streaming",
+      "title": "\u2018The Pete Davidson Show\u2019: SAG-AFTRA Signs Podcast Agreement With Netflix",
+      "url": "https://variety.com/2026/digital/news/pete-davidson-show-sag-aftra-podcast-agreement-netflix-1236661709/",
+      "published_at": "2026-02-13T00:11:23",
+      "snippet": "Netflix has described its recently released &#8220;The Pete Davidson Show&#8221; as a &#8220;video podcast&#8221; &#8212; and now SAG-AFTRA has signed an agreement with the streamer that covers the production as such. The talk show hosted by the &#8220;Saturday Night Live&#8221; alum, which debuted Jan. 30 on Netflix, sort of looks like a TV show. For [&#8230;]",
+      "hash": "6b5cf524eceec756"
+    },
+    {
+      "competitor_id": "roku_channel",
+      "source_label": "roku_news",
+      "title": "Roku Sees Higher Revenue, Positive Net Income For 2025 As Platform Makes Gains - The Hollywood Reporter",
+      "url": "https://news.google.com/rss/articles/CBMisAFBVV95cUxOTW5vVHZsYkJLQzN1SmtiTnlVX3ZqTEM0WW14SEJmWWY5MkFjcHhpZ2dPM3VxS1pDbUl0V1kwRm5aMjhLbmplNXlqd18zTVNEaHBEaE1yQ2JrRExIM2kwc0lscm1TYXhES1RXUS1GOUVMUHhDMWRKaEN1SElMREwyVEhNc3p1SVRkblQ4UkVsYXNJZ0k5d0Zfd1hKazNfNFRGM1EwbWJtWi1JelNkWG9ueA?oc=5",
+      "published_at": "2026-02-12T23:38:23",
+      "snippet": "Roku Sees Higher Revenue, Positive Net Income For 2025 As Platform Makes Gains&nbsp;&nbsp;The Hollywood Reporter",
+      "hash": "bc8b9818b5b14694"
+    },
+    {
+      "competitor_id": "roku_channel",
+      "source_label": "roku_news",
+      "title": "Roku Posts $80.5 Million Quarterly Profit Turnaround, Ups Platform Streaming Hours to 145.6 Billion - Media Play News",
+      "url": "https://news.google.com/rss/articles/CBMixwFBVV95cUxNS2pOTkthc0VYTDh0OV9zMEM4MkxFTndOQm5CQXJKWXlucjRFQkd1YTV0TG9VYTNxcjlhODFfUTBsb1R4a08tQmY1alpTdDNybDJ1MXJSZnpFMHlFaVZvN2QzZDVFVFBvWi1MTHJBelR1TlJpaGJlMjVLTzNxa1RKR1Y0M0dGeVhsUHp1MjFyNUZ5LUhsUkFFZFFtZ1o1Si11WGdjVTI1b1FMb1ZyUDl1U2pUR2FHSUFzalNQSmRhMjd5b3NRcXEw?oc=5",
+      "published_at": "2026-02-12T23:21:58",
+      "snippet": "Roku Posts $80.5 Million Quarterly Profit Turnaround, Ups Platform Streaming Hours to 145.6 Billion&nbsp;&nbsp;Media Play News",
+      "hash": "d39b61fe98703fa0"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "variety_streaming",
+      "title": "New \u2018God of War\u2019 Game \u2018Sons of Sparta\u2019 Surprise Launches on PlayStation, Original Trilogy Remake in the Works",
+      "url": "https://variety.com/2026/gaming/news/god-of-war-game-sons-of-sparta-original-trilogy-remake-1236661145/",
+      "published_at": "2026-02-12T23:17:27",
+      "snippet": "A new &#8220;God of War&#8221; game titled &#8220;Sons of Sparta&#8221; surprise launched for the PS5 on Thursday, just as PlayStation revealed a remake of the original &#8220;God of War&#8221; trilogy is in the works. Per a blog post shared by &#8220;God of War&#8221; developer Santa Monica Studio, &#8220;Over two decades ago in March 2005, God [&#8230;]",
+      "hash": "5ad7e2a375b90257"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "variety_streaming",
+      "title": "\u2018John Wick\u2019 Video Game in the Works",
+      "url": "https://variety.com/2026/gaming/news/john-wick-video-game-development-1236661666/",
+      "published_at": "2026-02-12T23:00:11",
+      "snippet": "A &#8220;John Wick&#8221; video game is in the works from Saber Interactive and Lionsgate with star Keanu Reeves reprising his role for the single-player third-person action title. Described as a AAA video game &#8220;tailored for mature audiences,&#8221; the title is currently in development for PlayStation 5, Xbox Series X and PC with &#8220;John Wick&#8221; film [&#8230;]",
+      "hash": "507b41d70c401008"
+    },
+    {
+      "competitor_id": "samsung_tv_plus",
+      "source_label": "samsung_newsroom",
+      "title": "From Hardware Roots to Global Media Platform: How Samsung TV Plus Reached 100 Million Users - samsung.com",
+      "url": "https://news.google.com/rss/articles/CBMivwFBVV95cUxQTENGUXNPLWtrampQOExQSlBiOGxwaU52enRVbXB3NXZ1MTgtRU1wLVgyRU1hamw1MmlQTHJIVE1xNjhGTjhWMXVTZG5XdTN4aFdUbWNNRHpiVDlJQVZwYzRpSDQ2Y2pzSzJySEotOHFmdTRFTTZJRTdHZXVDYlBpSklUN0xLb0h2UGt2a0xfNzBtZ2ZpZlhBblg3Mi1ja2p1THVyZ2g5VzR1NEJBMXlFeW9PdEg2LThBZnR6bVZsYw?oc=5",
+      "published_at": "2026-02-12T23:00:00",
+      "snippet": "From Hardware Roots to Global Media Platform: How Samsung TV Plus Reached 100 Million Users&nbsp;&nbsp;samsung.com",
+      "hash": "a58c61d22e6e38df"
+    },
+    {
+      "competitor_id": "tubi",
+      "source_label": "tubi_google_news",
+      "title": "Tubi Just Added James Cameron\u2019s Sci-Fi Classic Just Months After It Was Pulled From Streaming Over Banned Scene - ComicBook.com",
+      "url": "https://news.google.com/rss/articles/CBMi3gFBVV95cUxNNGtlMlFNamNfUU9KMWFxQWljLWFjX3dJUXRGbDdrbEVZMUNITU10dXJVcnFBU2ZwYm9GalQ1Szk2X3ZSLW1DSVhOTTJEY0Z6ZjNmQmp5Z2NRVDh3cDZ1X3J6akRsMnVfS2ZyNFJMSElNU2ZTM3NrMlVyZk8zNnR3d2R0bFlzSHBSRXZsT1FqSlVsaGl1R0N4ZjFZeU9ua1B0Rlp2dW5xTDRSb0VvZVFHbDA3bHVCa2tRVlJjbFJrUWxIVjEwXzVYV3FnaEtsV2hrNGZ1ZS1EQ1hXYjFoYkE?oc=5",
+      "published_at": "2026-02-12T21:30:00",
+      "snippet": "Tubi Just Added James Cameron\u2019s Sci-Fi Classic Just Months After It Was Pulled From Streaming Over Banned Scene&nbsp;&nbsp;ComicBook.com",
+      "hash": "7b44a9760396335c"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "cord_cutting",
+      "title": "Roku Made Over $4.7 Billion in 2025 - | Cord Cutters News",
+      "url": "https://news.google.com/rss/articles/CBMicEFVX3lxTE95allHUElGU1M1OTJVVUlDWmxnMldaX0Z5SDZ4eXNJYV9pSUVDMnNTN2otcjNXdG93SExhR1JBMjliZWVITmp0b2hzYU5BVXpKY212SVVVM3hGRVZONUFLbC1heHRuT3NXUDB4TV9ZZkbSAXhBVV95cUxOS2dqTXVzcDRzOExlYkNCRUpMTUFmREUyR0NJc1h3M2RKT3BsQ09QeVhtWE9EdExtUzcxdTdVY01ielp0V2UyLXRfNExua3JmeU5BcVNVUFhsWXB5d0pLMGQ1Uk9zbWNlSE5uRjF1M2wzelNZSlozdXk?oc=5",
+      "published_at": "2026-02-12T21:22:11",
+      "snippet": "Roku Made Over $4.7 Billion in 2025&nbsp;&nbsp;| Cord Cutters News",
+      "hash": "c931ca6104c70939"
+    },
+    {
+      "competitor_id": "roku_channel",
+      "source_label": "roku_news",
+      "title": "Roku Swings to Profit in Q4 on Record Streaming Subscription Sign-Ups, Forecasts 16% Revenue Growth in 2026 - Variety",
+      "url": "https://news.google.com/rss/articles/CBMikgFBVV95cUxPTlp3WjJXa3UxOUQxeW5WTTd3VnZUNk9SbUpYLTFuRm1nem5sYkhXYmJfczNnSG9EckR2T1RvZHNPeEN0NVBhTVpnZ2UzTjFsSVRqd1k1RDZ3ME1uYWZXbEpzN0l2LW9aU1dCNVZWVS0weWpkc2RRM3I5S0tsZUpabjlzQXRCc2tYeVdxdTVLVjF0dw?oc=5",
+      "published_at": "2026-02-12T21:05:00",
+      "snippet": "Roku Swings to Profit in Q4 on Record Streaming Subscription Sign-Ups, Forecasts 16% Revenue Growth in 2026&nbsp;&nbsp;Variety",
+      "hash": "e450c9e50fc0ef85"
+    },
+    {
+      "competitor_id": "roku_channel",
+      "source_label": "roku_news",
+      "title": "Roku Releases Fourth Quarter and Full Year 2025 Financial Results - Business Wire",
+      "url": "https://news.google.com/rss/articles/CBMivwFBVV95cUxPNlFadW5WWnR1anlEckhMQ19fQmVZWC1uZUZwcmstN2hXNXZtMmpfZnRJWGF2TklpRXc5dkRnem0zUnF0TWxOSFI2THVLdXU2Q2lDUHRFNzJ1QlpQZGR3U3ViVl9NMWNiSm5SMDVSWVR1czhuQ2FMQy1vaU1CZFpTRVdLY0JNU25UTWFVeGdIOVRNOWpwa2FmVTZxRWwxNGxwZHdYUDhNNGw5QXVheklkLUFxVlpsYy05UF8tUFVGVQ?oc=5",
+      "published_at": "2026-02-12T21:05:00",
+      "snippet": "Roku Releases Fourth Quarter and Full Year 2025 Financial Results&nbsp;&nbsp;Business Wire",
+      "hash": "9e13fa315fcbaa0e"
+    },
+    {
+      "competitor_id": "youtube_tv",
+      "source_label": "youtube_tv_sports",
+      "title": "How YouTube TV\u2019s Sports Plan Compares to Fubo, DirecTV Offers - Sportico.com",
+      "url": "https://news.google.com/rss/articles/CBMitAFBVV95cUxQRlpoSkl6bVFENnFaRnpBQUw0SUI4aF9PZGlwQW5ZZE40TEw5TmdCeFkyS2VhVWM1eS1aUnFPbzJfMXVZMkhMdm54aURDT2Y5aDVjSF9ZdENEcndGOUxJby1GdXRyRHp1NUVtd2lyeFotdVF5ZDJXUXJOMkF4RXNraXVzLUJPWXVidF96N2Z4Tk5ESXRQb0tPR2EwMFdsemhMUk54Vzk4LVo5TUpTV3pQZlR2Yno?oc=5",
+      "published_at": "2026-02-12T20:58:57",
+      "snippet": "How YouTube TV\u2019s Sports Plan Compares to Fubo, DirecTV Offers&nbsp;&nbsp;Sportico.com",
+      "hash": "5481ee38d29946c2"
+    },
+    {
+      "competitor_id": "peacock",
+      "source_label": "peacock_news",
+      "title": "Peacock may be the best streamer to watch live sports: here's why - Tom's Guide",
+      "url": "https://news.google.com/rss/articles/CBMisAFBVV95cUxNcXhQd2tYSlUzMVhJa1FLR2hXdnhGWjFXU3g0RDNCSWNRU0dZenNDNjhLSE1BVVdDaXVyRkdGRGVSVS0yMHVzWHZVR3lKQUR6bjBLbENFd3hzWHdSZTNfaWxILVdUTHRJQjg5SE5ENXNRQmFqNDBJQno1aFhsTy1nNnlyNmh5dU1yWVE4Ri1PU0syVVgzYnRSSmJBTGEzdy0wLUZkQ3BfcmlhcFNWazJEMQ?oc=5",
+      "published_at": "2026-02-12T19:28:18",
+      "snippet": "Peacock may be the best streamer to watch live sports: here's why&nbsp;&nbsp;Tom's Guide",
+      "hash": "db6a152434e936b6"
+    },
+    {
+      "competitor_id": "peacock",
+      "source_label": "peacock_news",
+      "title": "How to watch USA vs. Latvia men\u2019s hockey for free on DIRECTV, Peacock if you\u2019re blacked out on Fubo - Cleveland.com",
+      "url": "https://news.google.com/rss/articles/CBMi1gFBVV95cUxOQ1RfSHN1ZDJCUkZyMHdTeV9rTFEtQWFzV0dETzZFTWtCRlJtLWJMdTZBd1kyb1NUMUc4cExQVDZaeWhHQVdNRnhNSnF4TG95M2NHaV85UDdEbHotaVp6U3VXczBvZlNUTjZtN3N2OFFCdkV6QkZNZHBzNzRIa0Nwd1ZraHhvY1BFUElUdWZZdC1sWXBRTVdKVFN1cmdDc0dnT0Ztd1JYVjNZLTNJanI0OXFsaUlRMDFUV0tNTjRxdHRzZ3pEdFEtWm5Ka2RKWEF2QVVlSWFn0gHqAUFVX3lxTE1XRE5XaWg2TVhUbU1kb212YmZhMHZpTUxTQi03d3dsOHlmZjd5WVVfWEJPMmxxcnNTRFJnTHZ0TzYtMVp6UkVqbHdYQnR2eUN3NVBmWGUwc1l0RVpVeXRNd29WX3R6Tllwa3hfS3FuN0JJUTVHV3BfRnZQUEVXQ0NTclY3dkRUeUJMZ3NSeFJZM0NOcHVKakFpYkZvY0I1WVktSlc2UDdSU0lwdk1vZlk5c2trX1JIODhDUGRUaHh0Z3ozUmtvYmNsZjE5UmVKTVV4eDZLWnJ3cHYyc2lWS08ybnBOQjNOUFVTUQ?oc=5",
+      "published_at": "2026-02-12T18:40:00",
+      "snippet": "How to watch USA vs. Latvia men\u2019s hockey for free on DIRECTV, Peacock if you\u2019re blacked out on Fubo&nbsp;&nbsp;Cleveland.com",
+      "hash": "721971e4d2bf170d"
+    },
+    {
+      "competitor_id": "samsung_tv_plus",
+      "source_label": "samsung_tv_plus_news",
+      "title": "Major League Volleyball and Samsung TV Plus Serve Up FAST Partnership for League's Next Generation of Fans - Yahoo Finance Singapore",
+      "url": "https://news.google.com/rss/articles/CBMiiwFBVV95cUxNazA4NzJBalQxcHZHa04zMHc2b0VXdmtNR1E3NWl5OEJ0LTdhZEUxMXBlZmdGTXZMZzF3Qm9jLTVWTlFoMnpZSDBkNGEwalU1Q1NWYV9zNlNjUzZ3TTJSa3FtZTROVWUxaUNXR0xtS1M0MGFqZWlOZ3FBX2RJTEx6WWI1aG5sQTBZbFdz?oc=5",
+      "published_at": "2026-02-12T18:17:00",
+      "snippet": "Major League Volleyball and Samsung TV Plus Serve Up FAST Partnership for League's Next Generation of Fans&nbsp;&nbsp;Yahoo Finance Singapore",
+      "hash": "3551258a0599065f"
+    },
+    {
+      "competitor_id": "industry",
+      "source_label": "adweek",
+      "title": "Trump Tariffs Hit Pinterest&#8217;s Ad Revenues",
+      "url": "https://www.adweek.com/media/trump-tariffs-hit-pinterests-ad-revenues/",
+      "published_at": "2026-02-12T17:43:28",
+      "snippet": "Pinterest hopes that investing in more advanced AI capabilities for merchants and advertisers will help it make up lost ground on revenue.",
+      "hash": "3d572d8f6ea08cc8"
+    }
+  ],
+  "errors": []
+}

--- a/intel/scans/2026-02-15/20260215_173726/channels.json
+++ b/intel/scans/2026-02-15/20260215_173726/channels.json
@@ -1,0 +1,72 @@
+{
+  "xumo": {
+    "channel_count": 411,
+    "category_count": 26,
+    "categories": [
+      "Action \\u0026 Drama",
+      "Animals \\u0026 Nature",
+      "Automotive",
+      "Black Voices. Black Stories.",
+      "Classic TV",
+      "Combat Sports",
+      "Comedy",
+      "Crime TV",
+      "Daytime TV",
+      "Faith \\u0026 Family",
+      "Food",
+      "Game Shows",
+      "History \\u0026 Learning",
+      "Home \\u0026 Design",
+      "Horror \\u0026 Sci-Fi",
+      "Kids",
+      "Latino",
+      "Local News",
+      "Movies",
+      "Music \\u0026 Radio",
+      "News",
+      "Pop Culture",
+      "Reality TV",
+      "Sports",
+      "Travel \\u0026 Lifestyle",
+      "Westerns \\u0026 Country"
+    ],
+    "method": "slug count from page JSON",
+    "url": "https://play.xumo.com/channels",
+    "date": "2026-02-15",
+    "page_size": 457094
+  },
+  "samsung": {
+    "channel_count_claimed": 300,
+    "method": "marketing text extraction (no channel list exposed in HTML)",
+    "note": "Samsung does not expose channel names in HTML; count is from marketing copy",
+    "url": "https://www.samsung.com/us/tvplus/",
+    "date": "2026-02-15",
+    "page_size": 496638
+  },
+  "pluto": {
+    "channel_count_titles": 0,
+    "channel_count_slugs": 0,
+    "categories": [],
+    "method": "title/slug count from page (may be incomplete due to dynamic loading)",
+    "url": "https://pluto.tv/en/live-tv",
+    "date": "2026-02-15",
+    "page_size": 30099
+  },
+  "tubi": {
+    "initial_load_count": 0,
+    "note": "Full channel count requires dynamic page rendering. User reports ~340 channels total.",
+    "sample_channels": [],
+    "method": "title extraction from initial HTML (partial)",
+    "url": "https://tubitv.com/live",
+    "date": "2026-02-15",
+    "page_size": 125869
+  },
+  "vizio": {
+    "channel_count_claimed": 300,
+    "title_count": 0,
+    "method": "marketing text + title extraction",
+    "url": "https://www.vizio.com/en/watchfreeplus",
+    "date": "2026-02-15",
+    "page_size": 192371
+  }
+}

--- a/intel/scans/2026-02-15/20260215_173726/classified.json
+++ b/intel/scans/2026-02-15/20260215_173726/classified.json
@@ -1,0 +1,9 @@
+{
+  "all_classified": [],
+  "filtered": [],
+  "tokens": {
+    "prompt_tokens": 0,
+    "completion_tokens": 0,
+    "total_tokens": 0
+  }
+}

--- a/intel/scans/2026-02-15/20260215_173726/report.md
+++ b/intel/scans/2026-02-15/20260215_173726/report.md
@@ -1,0 +1,25 @@
+# Competitive Intelligence Report — 2026-02-15
+
+> Run ID: 20260215_173726
+> Started: 2026-02-15T17:37:26.805906
+> Completed: 2026-02-15T17:37:44.160502
+> Articles: 141 collected, 0 classified
+> Threats: 0 | Opportunities: 0 | Trends: 0
+
+---
+
+## All Classified Intel
+
+| # | Category | Rel | Imp | Competitor | Title |
+|---|---|---|---|---|---|
+
+## Channel Count Snapshot
+
+| Service | Count | Method | Date |
+|---|---|---|---|
+| xumo | 411 | slug count from page JSON | 2026-02-15 |
+| samsung | 300 | marketing text extraction (no channel li | 2026-02-15 |
+| pluto | ? | title/slug count from page (may be incom | 2026-02-15 |
+| tubi | ? | title extraction from initial HTML (part | 2026-02-15 |
+| vizio | 300 | marketing text + title extraction | 2026-02-15 |
+

--- a/intel/scans/2026-02-15/20260215_173726/run.json
+++ b/intel/scans/2026-02-15/20260215_173726/run.json
@@ -1,0 +1,12 @@
+{
+  "run_id": "20260215_173726",
+  "started_at": "2026-02-15T17:37:26.805906",
+  "finished_at": "2026-02-15T17:37:44.160502",
+  "status": "completed",
+  "articles_collected": 141,
+  "articles_classified": 0,
+  "threats_found": 0,
+  "opportunities_found": 0,
+  "trends_identified": 0,
+  "report_path": ""
+}


### PR DESCRIPTION
## Summary

- Ran competitive intel scan (`orchestrator.py --skip-memory`) collecting 141 articles from 41 RSS feeds and channel count data from 5 competitors
- Pushed 8 key learnings to strategy hub at `localhost:8888/api/strategy/learnings` (IDs 14-21)
- Created summary report at `analysis/reports/2026-02-15-ci-scan-summary.md`

### Key findings pushed as learnings:
1. Roku Q4 2025 profit turnaround — $80.5M profit, 145.6B streaming hours
2. Tubi acquiring Cartoon Network content — launching March 1st
3. YouTube TV launching cheaper bundles including standalone sports package
4. Samsung TV Plus reached 100M users globally
5. Channel count snapshot — Xumo 411, Samsung 300+, Vizio 300+, Tubi ~340
6. Fubo-Disney merger synergy materializing
7. World Baseball Classic on FOX/FS1/Tubi
8. Peacock dominating live sports coverage (20 articles)

### Notes:
- Classification/analysis phases skipped due to missing OPENAI_API_KEY — raw articles still valuable
- Opportunity: Re-run with API key for full AI classification and threat/opportunity scoring

## Test plan
- [x] Orchestrator ran successfully (141 articles, 5 channel scrapes)
- [x] Learnings POST returned valid IDs (14-21) from hub API
- [x] Summary report created with all findings
- [x] Scan output files committed (articles.json, channels.json, classified.json, report.md, run.json)

🤖 Generated with [Claude Code](https://claude.com/claude-code)