### PR TITLE
Wire CI scanner output into hub work queue

### DIFF
--- a/hub/routers/intel.py
+++ b/hub/routers/intel.py
@@ -1,6 +1,7 @@
 """Intel monitor: competitive intelligence pipeline results."""
 
 import json
+import logging
 import subprocess
 import sys
 from pathlib import Path
@@ -8,8 +9,10 @@ from pathlib import Path
 from fastapi import APIRouter, BackgroundTasks, Query
 
 from ..config import SCANS_DIR, SCANNER_DIR
+from .. import db
 
 router = APIRouter(prefix="/api/intel", tags=["intel"])
+logger = logging.getLogger(__name__)
 
 
 def _load_run_data(scan_date: str, run_id: str) -> dict:
@@ -101,13 +104,121 @@ def get_competitors():
     return analysis.get("profiles", [])
 
 
+def _get_sorted_runs() -> list[dict]:
+    """Return all scan runs sorted newest-first, each with date and run_id."""
+    runs = []
+    if not SCANS_DIR.exists():
+        return runs
+    for date_dir in sorted(SCANS_DIR.iterdir(), reverse=True):
+        if not date_dir.is_dir():
+            continue
+        for run_dir in sorted(date_dir.iterdir(), reverse=True):
+            if not run_dir.is_dir():
+                continue
+            run_file = run_dir / "run.json"
+            if run_file.exists():
+                with open(run_file) as f:
+                    run_data = json.load(f)
+                runs.append({"date": date_dir.name, "run_id": run_dir.name, **run_data})
+    return runs
+
+
+def _ingest_scan_results(scan_date: str, run_id: str) -> dict:
+    """Parse scan output and push threats/opportunities as work items.
+
+    Returns summary of what was ingested.
+    """
+    run_dir = SCANS_DIR / scan_date / run_id
+    ingested = {"threats": 0, "opportunities": 0, "work_item_ids": []}
+
+    # Load analysis.json for threats and opportunities
+    analysis_path = run_dir / "analysis.json"
+    if not analysis_path.exists():
+        return ingested
+
+    with open(analysis_path) as f:
+        analysis = json.load(f)
+
+    # Ingest threats as work items
+    threats_data = analysis.get("threats", {})
+    threats_list = threats_data.get("threats", []) if isinstance(threats_data, dict) else []
+    for threat in threats_list:
+        title = threat.get("title") or threat.get("description", "")[:80]
+        description = threat.get("description", "")
+        if threat.get("defensive_action"):
+            description += f"\n\nDefensive action: {threat['defensive_action']}"
+        metadata = {
+            "source": "ci_scan",
+            "scan_date": scan_date,
+            "run_id": run_id,
+            "threat_type": threat.get("threat_type", ""),
+            "severity": threat.get("severity", 0),
+            "timeframe": threat.get("timeframe", ""),
+            "source_competitor": threat.get("source_competitor", ""),
+        }
+        wid = db.create_work_item(
+            type="threat",
+            title=title,
+            description=description,
+            priority="high",
+            tags=["ci_scan", "threat", scan_date],
+            metadata=metadata,
+        )
+        ingested["threats"] += 1
+        ingested["work_item_ids"].append(wid)
+
+    # Ingest opportunities as work items
+    opps_data = analysis.get("opportunities", {})
+    opps_list = opps_data.get("opportunities", []) if isinstance(opps_data, dict) else []
+    for opp in opps_list:
+        title = opp.get("title") or opp.get("description", "")[:80]
+        description = opp.get("description", "")
+        if opp.get("action_items"):
+            description += "\n\nAction items:\n" + "\n".join(
+                f"- {a}" for a in opp["action_items"]
+            )
+        potential = opp.get("potential_value", 0)
+        feasibility = opp.get("feasibility", 0)
+        # High priority if value*feasibility score is above 40
+        priority = "high" if (potential * feasibility) > 40 else "medium"
+        metadata = {
+            "source": "ci_scan",
+            "scan_date": scan_date,
+            "run_id": run_id,
+            "opportunity_type": opp.get("opportunity_type", ""),
+            "potential_value": potential,
+            "feasibility": feasibility,
+            "competitor_gap": opp.get("competitor_gap", ""),
+        }
+        wid = db.create_work_item(
+            type="opportunity",
+            title=title,
+            description=description,
+            priority=priority,
+            tags=["ci_scan", "opportunity", scan_date],
+            metadata=metadata,
+        )
+        ingested["opportunities"] += 1
+        ingested["work_item_ids"].append(wid)
+
+    return ingested
+
+
 def _run_scan(args: list):
-    """Run the scanner pipeline (background task)."""
+    """Run the scanner pipeline (background task), then ingest results."""
     subprocess.run(
         [sys.executable, str(SCANNER_DIR / "orchestrator.py")] + args,
         cwd=str(SCANNER_DIR.parent.parent),
         capture_output=True,
     )
+    # After scan completes, find the newest run and ingest
+    runs = _get_sorted_runs()
+    if runs:
+        latest = runs[0]
+        try:
+            _ingest_scan_results(latest["date"], latest["run_id"])
+        except Exception:
+            logger.exception("Failed to ingest scan results")
 
 
 @router.post("/scan")
@@ -115,7 +226,11 @@ def trigger_scan(background_tasks: BackgroundTasks,
                  skip_memory: bool = False,
                  skip_analysis: bool = False,
                  competitor: str = None):
-    """Trigger a new competitive intelligence scan."""
+    """Trigger a new competitive intelligence scan.
+
+    After the scan completes, threats and opportunities are auto-ingested
+    as work items in the hub database.
+    """
     args = []
     if skip_memory:
         args.append("--skip-memory")
@@ -125,3 +240,103 @@ def trigger_scan(background_tasks: BackgroundTasks,
         args.extend(["--competitor", competitor])
     background_tasks.add_task(_run_scan, args)
     return {"status": "scan_started", "args": args}
+
+
+@router.post("/ingest/{scan_date}/{run_id}")
+def ingest_run(scan_date: str, run_id: str):
+    """Manually ingest a scan run's threats/opportunities into the work queue."""
+    run_dir = SCANS_DIR / scan_date / run_id
+    if not run_dir.exists():
+        return {"error": f"Run not found: {scan_date}/{run_id}"}
+    result = _ingest_scan_results(scan_date, run_id)
+    return {"status": "ingested", **result}
+
+
+@router.get("/history")
+def scan_history():
+    """List all past scan runs with article count, threat count, and date."""
+    history = []
+    for run in _get_sorted_runs():
+        run_dir = SCANS_DIR / run["date"] / run["run_id"]
+        entry = {
+            "date": run["date"],
+            "run_id": run["run_id"],
+            "started_at": run.get("started_at", ""),
+            "finished_at": run.get("finished_at", ""),
+            "status": run.get("status", "unknown"),
+            "article_count": run.get("articles_collected", 0),
+            "classified_count": run.get("articles_classified", 0),
+            "threat_count": run.get("threats_found", 0),
+            "opportunity_count": run.get("opportunities_found", 0),
+            "trend_count": run.get("trends_identified", 0),
+        }
+        history.append(entry)
+    return history
+
+
+@router.get("/diff")
+def scan_diff():
+    """Compare the latest two scans and return new/changed items.
+
+    Compares classified intel titles and analysis items between the two
+    most recent runs.
+    """
+    runs = _get_sorted_runs()
+    if len(runs) < 2:
+        return {"error": "Need at least 2 scan runs to diff", "runs_available": len(runs)}
+
+    latest = _load_run_data(runs[0]["date"], runs[0]["run_id"])
+    previous = _load_run_data(runs[1]["date"], runs[1]["run_id"])
+
+    def _extract_titles(data: dict, path: str) -> set:
+        """Extract a set of titles/names from nested scan data."""
+        parts = path.split(".")
+        obj = data
+        for p in parts:
+            if isinstance(obj, dict):
+                obj = obj.get(p, {})
+            else:
+                return set()
+        if isinstance(obj, list):
+            return {item.get("title") or item.get("name", "") for item in obj if isinstance(item, dict)}
+        return set()
+
+    # Compare classified intel
+    latest_classified = _extract_titles(latest, "classified.filtered")
+    if not latest_classified:
+        latest_classified = _extract_titles(latest, "classified.intel")
+    prev_classified = _extract_titles(previous, "classified.filtered")
+    if not prev_classified:
+        prev_classified = _extract_titles(previous, "classified.intel")
+
+    # Compare threats
+    latest_threats = _extract_titles(latest, "analysis.threats.threats")
+    prev_threats = _extract_titles(previous, "analysis.threats.threats")
+
+    # Compare opportunities
+    latest_opps = _extract_titles(latest, "analysis.opportunities.opportunities")
+    prev_opps = _extract_titles(previous, "analysis.opportunities.opportunities")
+
+    # Compare trends
+    latest_trends = _extract_titles(latest, "analysis.trends.trends")
+    prev_trends = _extract_titles(previous, "analysis.trends.trends")
+
+    return {
+        "latest": {"date": runs[0]["date"], "run_id": runs[0]["run_id"]},
+        "previous": {"date": runs[1]["date"], "run_id": runs[1]["run_id"]},
+        "new_intel": sorted(latest_classified - prev_classified),
+        "removed_intel": sorted(prev_classified - latest_classified),
+        "new_threats": sorted(latest_threats - prev_threats),
+        "removed_threats": sorted(prev_threats - latest_threats),
+        "new_opportunities": sorted(latest_opps - prev_opps),
+        "removed_opportunities": sorted(prev_opps - latest_opps),
+        "new_trends": sorted(latest_trends - prev_trends),
+        "removed_trends": sorted(prev_trends - latest_trends),
+        "summary": {
+            "new_intel_count": len(latest_classified - prev_classified),
+            "removed_intel_count": len(prev_classified - latest_classified),
+            "new_threats_count": len(latest_threats - prev_threats),
+            "new_opportunities_count": len(latest_opps - prev_opps),
+            "new_trends_count": len(latest_trends - prev_trends),
+        },
+    }

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -567,6 +567,67 @@ if named_result and "available" in named_result:
 
 
 # ============================================================
+# PHASE 8: Test new intel endpoints (history, diff, ingest)
+# ============================================================
+print("\n" + "=" * 60)
+print("PHASE 8: Testing intel history, diff, and ingest endpoints")
+print("=" * 60)
+
+# GET /api/intel/history — list all past scans with counts
+history = test_get("GET /api/intel/history", "/api/intel/history", expect_type=list)
+if history:
+    report("Intel history has entries", len(history) > 0, f"found {len(history)} scan runs")
+    first = history[0]
+    report("History entry has date", "date" in first, f"keys={list(first.keys())}")
+    report("History entry has article_count", "article_count" in first,
+           f"article_count={first.get('article_count')}")
+    report("History entry has threat_count", "threat_count" in first,
+           f"threat_count={first.get('threat_count')}")
+    report("History entry has opportunity_count", "opportunity_count" in first,
+           f"opportunity_count={first.get('opportunity_count')}")
+
+# GET /api/intel/diff — compare latest two scans
+diff = test_get("GET /api/intel/diff", "/api/intel/diff")
+if diff:
+    if "error" not in diff:
+        report("Diff has latest/previous refs", "latest" in diff and "previous" in diff,
+               f"latest={diff.get('latest', {}).get('run_id')}, prev={diff.get('previous', {}).get('run_id')}")
+        report("Diff has summary", "summary" in diff, f"summary={diff.get('summary')}")
+        report("Diff has new_intel list", isinstance(diff.get("new_intel"), list),
+               f"new_intel_count={len(diff.get('new_intel', []))}")
+        report("Diff has new_threats list", isinstance(diff.get("new_threats"), list),
+               f"new_threats_count={len(diff.get('new_threats', []))}")
+    else:
+        report("Diff returns error (need 2+ runs)", "runs_available" in diff,
+               f"error={diff.get('error')}")
+
+# POST /api/intel/ingest — manually ingest a scan run
+if history and len(history) > 0:
+    ingest_date = history[0]["date"]
+    ingest_run_id = history[0]["run_id"]
+    ingest_result = test_post("POST /api/intel/ingest (manual)",
+        f"/api/intel/ingest/{ingest_date}/{ingest_run_id}", {})
+    if ingest_result:
+        report("Ingest returned status", ingest_result.get("status") == "ingested",
+               f"threats={ingest_result.get('threats')}, opps={ingest_result.get('opportunities')}")
+        report("Ingest created work items", isinstance(ingest_result.get("work_item_ids"), list),
+               f"count={len(ingest_result.get('work_item_ids', []))}")
+
+    # Verify work items were created
+    work_items = test_get("GET /api/strategy/work?type=threat", "/api/strategy/work?type=threat", expect_type=list)
+    if work_items:
+        ci_threats = [w for w in work_items if "ci_scan" in (w.get("tags") or "")]
+        report("Threat work items created from scan", len(ci_threats) > 0,
+               f"found {len(ci_threats)} threat work items with ci_scan tag")
+
+    work_items_opp = test_get("GET /api/strategy/work?type=opportunity", "/api/strategy/work?type=opportunity", expect_type=list)
+    if work_items_opp:
+        ci_opps = [w for w in work_items_opp if "ci_scan" in (w.get("tags") or "")]
+        report("Opportunity work items created from scan", len(ci_opps) > 0,
+               f"found {len(ci_opps)} opportunity work items with ci_scan tag")
+
+
+# ============================================================
 # SUMMARY
 # ============================================================
 print("\n" + "=" * 60)


### PR DESCRIPTION
## Summary
- After `POST /api/intel/scan` completes, threats from `analysis.json` are auto-pushed as work items (`type=threat`, `priority=high`) and opportunities as work items (`type=opportunity`, priority based on value×feasibility score) to the hub database via `hub/db.py`
- Added `GET /api/intel/history` — lists all past scan runs with article count, threat count, opportunity count, and date
- Added `GET /api/intel/diff` — compares the latest two scans and returns new/changed/removed items across classified intel, threats, opportunities, and trends
- Added `POST /api/intel/ingest/{date}/{run_id}` — manual trigger for ingesting a specific scan run's results

## Files changed
- `hub/routers/intel.py` — core logic for ingest, history, and diff endpoints
- `tests/test_api_endpoints.py` — Phase 8 tests covering all new endpoints (merged with upstream Sprout Social tests)

## Test plan
- [x] `GET /api/intel/history` returns list of scan runs with correct counts
- [x] `GET /api/intel/diff` returns diff structure with latest/previous refs and summary
- [x] `POST /api/intel/ingest/{date}/{run_id}` creates threat and opportunity work items
- [x] Work items appear in `GET /api/strategy/work?type=threat` and `?type=opportunity`
- [x] All tested via curl against localhost:8889

## Notes
- Ingesting the same scan run twice will create duplicate work items. A dedup mechanism (checking metadata.run_id + title) could be added as a follow-up.
- The diff endpoint compares by title/name strings — more sophisticated matching (e.g., fuzzy or hash-based) could improve accuracy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)