### PR TITLE
Replace PRD template with OpenAI-powered PRD generator

### DIFF
--- a/hub/db.py
+++ b/hub/db.py
@@ -4,6 +4,7 @@ import json
 import sqlite3
 from contextlib import contextmanager
 from datetime import datetime
+from typing import Optional
 
 from .config import HUB_DB_PATH
 
@@ -175,6 +176,16 @@ CREATE TABLE IF NOT EXISTS kpi_cache (
     key TEXT PRIMARY KEY,
     value TEXT NOT NULL,           -- JSON-encoded result
     fetched_at TEXT NOT NULL       -- ISO timestamp of when data was fetched
+);
+
+-- Generated PRDs
+CREATE TABLE IF NOT EXISTS prds (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    topic TEXT NOT NULL,
+    content_md TEXT NOT NULL,
+    status TEXT DEFAULT 'draft',   -- draft, reviewed, approved
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
 );
 
 -- QA accuracy checks: continuous data verification
@@ -572,6 +583,49 @@ def set_cached_kpi(key: str, value) -> None:
         )
 
 
+# --- PRDs ---
+
+def create_prd(topic: str, content_md: str, status: str = "draft") -> int:
+    with get_db() as conn:
+        cur = conn.execute(
+            """INSERT INTO prds (topic, content_md, status, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?)""",
+            (topic, content_md, status, now_iso(), now_iso())
+        )
+        return cur.lastrowid
+
+
+def get_prds(status: str = None, limit: int = 100) -> list:
+    with get_db() as conn:
+        query = "SELECT * FROM prds WHERE 1=1"
+        params = []
+        if status:
+            query += " AND status = ?"
+            params.append(status)
+        query += " ORDER BY created_at DESC LIMIT ?"
+        params.append(limit)
+        return [dict(r) for r in conn.execute(query, params).fetchall()]
+
+
+def get_prd(id: int) -> Optional[dict]:
+    with get_db() as conn:
+        row = conn.execute("SELECT * FROM prds WHERE id = ?", (id,)).fetchone()
+        return dict(row) if row else None
+
+
+def update_prd(id: int, **kwargs) -> bool:
+    allowed = {"topic", "content_md", "status"}
+    updates = {k: v for k, v in kwargs.items() if k in allowed}
+    if not updates:
+        return False
+    updates["updated_at"] = now_iso()
+    set_clause = ", ".join(f"{k} = ?" for k in updates)
+    with get_db() as conn:
+        conn.execute(f"UPDATE prds SET {set_clause} WHERE id = ?",
+                     list(updates.values()) + [id])
+    return True
+
+
 # --- Data Sources (Monitoring) ---
 
 def upsert_data_source(source_name: str, status: str = "unknown",
@@ -750,7 +804,6 @@ def get_insights(limit: int = 100) -> list:
     with get_db() as conn:
         return [dict(r) for r in conn.execute(
             "SELECT * FROM insights ORDER BY created_at DESC LIMIT ?", (limit,)).fetchall()]
->>>>>>> 3fe94d3 (Add knowledge engine: PRD reviewer, idea generator, insight synthesizer, weekly digest)
 
 
 # Initialize on import

--- a/hub/routers/strategy.py
+++ b/hub/routers/strategy.py
@@ -1,12 +1,16 @@
 """Strategy workspace: PRDs, decisions, work items, learnings, change log."""
 
 import json
+import logging
 from typing import Optional
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 from .. import db
+from ..config import OPENAI_API_KEY
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/strategy", tags=["strategy"])
 
@@ -158,72 +162,184 @@ def create_change(c: ChangeCreate):
 
 # --- PRD Generator ---
 
-@router.post("/generate-prd")
-def generate_prd(context: dict):
-    """Generate a PRD template with context from all modules."""
-    title = context.get("title", "Untitled PRD")
-    problem = context.get("problem", "")
-    hypothesis = context.get("hypothesis", "")
+class PRDRequest(BaseModel):
+    topic: str
+    context: str = ""
 
-    # Pull relevant data
+
+class PRDUpdate(BaseModel):
+    status: Optional[str] = None
+    content_md: Optional[str] = None
+
+
+def _gather_hub_context(topic: str) -> dict:
+    """Pull all relevant context from the hub for PRD generation."""
+    # Sentiment topics — what users complain/talk about most
+    feedback_items = db.get_feedback(limit=200)
+    topic_counts = {}
+    for item in feedback_items:
+        topics = item.get("topics", "[]")
+        if isinstance(topics, str):
+            topics = json.loads(topics)
+        for t in topics:
+            topic_counts[t] = topic_counts.get(t, 0) + 1
+    sorted_topics = sorted(topic_counts.items(), key=lambda x: -x[1])[:15]
+    sentiment_summary = db.get_sentiment_summary()
+
+    # Grab actual negative feedback quotes for context
+    negative_feedback = [
+        f for f in feedback_items
+        if f.get("sentiment") == "negative"
+    ][:10]
+
+    # Competitive threats — from latest intel scan
+    from .intel import get_threats, get_opportunities
+    threats = get_threats()
+    opportunities = get_opportunities()
+
+    # Current metrics from dashboard
+    from .dashboard import get_overview, get_goals
+    overview = get_overview()
+    goals = get_goals()
+
+    # Open work items
+    work_items = db.get_work_items(status="open", limit=20)
+    in_progress = db.get_work_items(status="in_progress", limit=20)
+
+    # Experiment results
+    experiments = db.get_experiments(limit=20)
+    for exp in experiments:
+        for field in ("platforms", "metrics"):
+            if isinstance(exp.get(field), str):
+                exp[field] = json.loads(exp[field])
+
+    # Learnings
+    learnings = db.get_learnings(limit=20)
+
+    # Verifications
     verifications = db.get_verifications(limit=10)
-    feedback = db.get_feedback(limit=20)
-    learnings = db.get_learnings(limit=10)
-    experiments = db.get_experiments(limit=10)
 
-    prd_md = f"""# {title}
+    return {
+        "topic": topic,
+        "sentiment_topics": sorted_topics,
+        "sentiment_summary": sentiment_summary,
+        "negative_feedback": [
+            {"text": f["text"], "source": f["source"], "score": f.get("sentiment_score")}
+            for f in negative_feedback
+        ],
+        "threats": threats[:10] if isinstance(threats, list) else [],
+        "opportunities": opportunities[:10] if isinstance(opportunities, list) else [],
+        "kpis": overview.get("kpis", {}),
+        "goals": goals,
+        "work_open": [{"title": w["title"], "type": w["type"], "priority": w["priority"]} for w in work_items[:10]],
+        "work_in_progress": [{"title": w["title"], "type": w["type"]} for w in in_progress[:10]],
+        "experiments": [
+            {"name": e["name"], "status": e["status"], "hypothesis": e.get("hypothesis", ""),
+             "metrics": e.get("metrics", {})}
+            for e in experiments[:10]
+        ],
+        "learnings": [
+            {"title": l["title"], "category": l["category"], "description": l["description"][:200]}
+            for l in learnings[:10]
+        ],
+        "verifications": [
+            {"metric": v["metric_name"], "expected": v["expected_value"],
+             "actual": v["actual_value"], "status": v["match_status"]}
+            for v in verifications[:10]
+        ],
+    }
 
-> Date: {{date}}
-> Author: {{author}}
-> Status: DRAFT
 
-## Problem Statement
-{problem}
+def _build_prd_prompt(topic: str, user_context: str, hub_data: dict) -> str:
+    """Build the system + user prompt for OpenAI PRD generation."""
+    system = """You are a senior product manager at Tubi, a free ad-supported streaming service.
+You write concise, data-driven PRDs that reference real metrics and user feedback.
+Your PRDs are actionable and grounded in evidence, not aspirational fluff.
 
-## Hypothesis
-{hypothesis}
+Output a complete PRD in markdown format with these exact sections:
+1. **Problem Statement** — derived from sentiment data and competitive threats
+2. **User Need** — backed by actual user quotes and sentiment data
+3. **Proposed Solution** — concrete description of what to build
+4. **Success Metrics** — table with Metric, Current Baseline, Target, Guardrail columns using real numbers
+5. **Competitive Context** — what competitors are doing in this space
+6. **Risks and Open Questions** — honest assessment
+7. **Implementation Phases** — phased rollout plan
 
-## Evidence
+Use the hub data provided to ground every section in real numbers and quotes.
+Do NOT invent data — if something is missing, note it as a gap."""
 
-### Data Verifications
+    hub_summary = json.dumps(hub_data, indent=2, default=str)
+
+    user_msg = f"""Generate a PRD for: **{topic}**
+
+Additional context from the requester:
+{user_context if user_context else "(none provided)"}
+
+--- HUB DATA (real data from our systems) ---
+{hub_summary}
 """
-    for v in verifications[:5]:
-        prd_md += f"- **{v['metric_name']}**: expected={v['expected_value']}, actual={v['actual_value']} ({v['match_status']})\n"
+    return system, user_msg
 
-    prd_md += "\n### User Feedback Themes\n"
-    sentiment = db.get_sentiment_summary()
-    prd_md += f"- Total feedback items: {sentiment['total']}\n"
-    prd_md += f"- Average sentiment: {sentiment['avg_score']}\n"
-    for s, c in sentiment.get("by_sentiment", {}).items():
-        prd_md += f"- {s}: {c}\n"
 
-    prd_md += "\n### Relevant Learnings\n"
-    for l in learnings[:5]:
-        prd_md += f"- [{l['category']}] {l['title']}: {l['description'][:100]}\n"
+@router.post("/generate-prd")
+def generate_prd(req: PRDRequest):
+    """Generate a PRD using OpenAI, grounded in all hub data."""
+    if not OPENAI_API_KEY:
+        raise HTTPException(status_code=500, detail="OPENAI_API_KEY not configured")
 
-    prd_md += """
-## Solution
+    # 1. Gather all hub context
+    hub_data = _gather_hub_context(req.topic)
 
-### What we're building
-[TODO]
+    # 2. Build prompt
+    system_prompt, user_prompt = _build_prd_prompt(req.topic, req.context, hub_data)
 
-### What we're NOT building
-[TODO]
+    # 3. Call OpenAI
+    try:
+        from openai import OpenAI
+        client = OpenAI(api_key=OPENAI_API_KEY)
+        response = client.chat.completions.create(
+            model="gpt-4o",
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+            temperature=0.7,
+            max_tokens=4000,
+        )
+        prd_md = response.choices[0].message.content
+    except Exception as e:
+        logger.error("OpenAI PRD generation failed: %s", e)
+        raise HTTPException(status_code=502, detail=f"OpenAI call failed: {e}")
 
-## Success Metrics
-| Metric | Baseline | Target | Guardrail |
-|--------|----------|--------|-----------|
-| Linear TVT | | | |
-| Global TVT | | | |
-| Conversion | | | |
+    # 4. Store in database
+    prd_id = db.create_prd(topic=req.topic, content_md=prd_md)
 
-## Experiment Plan
-[TODO]
+    return {"id": prd_id, "topic": req.topic, "status": "draft", "prd_markdown": prd_md}
 
-## Risks & Mitigations
-[TODO]
 
-## Timeline
-[TODO]
-"""
-    return {"prd_markdown": prd_md}
+@router.get("/prds")
+def list_prds(status: Optional[str] = None, limit: int = 100):
+    """List all generated PRDs."""
+    return db.get_prds(status=status, limit=limit)
+
+
+@router.get("/prds/{prd_id}")
+def get_prd(prd_id: int):
+    """Get a single PRD by ID."""
+    prd = db.get_prd(prd_id)
+    if not prd:
+        raise HTTPException(status_code=404, detail="PRD not found")
+    return prd
+
+
+@router.put("/prds/{prd_id}")
+def update_prd(prd_id: int, update: PRDUpdate):
+    """Update PRD status or content after review."""
+    existing = db.get_prd(prd_id)
+    if not existing:
+        raise HTTPException(status_code=404, detail="PRD not found")
+    kwargs = {k: v for k, v in update.model_dump().items() if v is not None}
+    if not kwargs:
+        raise HTTPException(status_code=400, detail="No fields to update")
+    db.update_prd(prd_id, **kwargs)
+    return {"updated": True, "id": prd_id}

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -390,12 +390,32 @@ test_post("POST /api/strategy/changelog",
      "impact": "Updates competitive positioning analysis",
      "evidence": "Manual count + browser scrape", "tags": ["channels", "competitive"]})
 
-# Strategy: generate-prd
-test_post("POST /api/strategy/generate-prd",
+# Strategy: generate-prd (requires OPENAI_API_KEY — test accepts 200 or 500)
+prd_result = test_post("POST /api/strategy/generate-prd",
     "/api/strategy/generate-prd",
-    {"title": "EPG Redesign PRD", "problem": "Current EPG is slow and hard to navigate",
-     "hypothesis": "A modern horizontal-scroll EPG will increase linear TVT by 5%"},
-    expect_key="prd_markdown")
+    {"topic": "EPG Navigation Redesign", "context": "Focus on reducing clicks to switch channels"})
+# If OPENAI_API_KEY is set, we get a PRD back; otherwise 500 is expected
+if prd_result and "prd_markdown" in prd_result:
+    report("PRD has markdown content", len(prd_result["prd_markdown"]) > 50,
+           f"length={len(prd_result['prd_markdown'])}")
+    report("PRD has id", "id" in prd_result, f"id={prd_result.get('id')}")
+
+# Strategy: PRD CRUD endpoints
+test_get("GET /api/strategy/prds", "/api/strategy/prds", expect_type=list)
+# Test GET single PRD (404 for non-existent)
+try:
+    r = requests.get(f"{BASE}/api/strategy/prds/99999", timeout=10)
+    report("GET /api/strategy/prds/99999 returns 404", r.status_code == 404,
+           f"status={r.status_code}")
+except Exception as e:
+    report("GET /api/strategy/prds/99999", False, str(e))
+# Test PUT PRD (404 for non-existent)
+try:
+    r = requests.put(f"{BASE}/api/strategy/prds/99999", json={"status": "approved"}, timeout=10)
+    report("PUT /api/strategy/prds/99999 returns 404", r.status_code == 404,
+           f"status={r.status_code}")
+except Exception as e:
+    report("PUT /api/strategy/prds/99999", False, str(e))
 
 # OEM: gracenote
 test_post("POST /api/oem/gracenote",


### PR DESCRIPTION
## Summary
- Replaced the static template-based `/api/strategy/generate-prd` with a real OpenAI gpt-4o powered PRD generator
- New endpoint accepts `{topic, context}` and pulls ALL hub data (sentiment topics, negative feedback quotes, competitive threats/opportunities, dashboard KPIs, goals, work items, experiments, learnings, verifications) to build a grounded PRD
- Added `prds` table in SQLite for persistent storage of generated PRDs
- Added `GET /api/strategy/prds` to list all PRDs with optional status filter
- Added `GET /api/strategy/prds/{id}` to get a single PRD
- Added `PUT /api/strategy/prds/{id}` to update PRD status (draft → reviewed → approved) or content
- Resolved merge conflict with kpi_cache table from another PR
- Updated test suite for new endpoint contract

## Test plan
- [x] Verified all imports work correctly
- [x] Integration tested with mocked OpenAI (gpt-4o model, hub data in prompt confirmed)
- [x] Verified PRD CRUD: create, list, get, update status, 404 handling
- [x] Updated test suite in `tests/test_api_endpoints.py` for new `{topic, context}` request format
- [ ] Live test with real OPENAI_API_KEY (requires .env setup)

## Notes
- The dashboard router now queries Databricks (from another merged PR) — those warnings are expected without credentials
- Opportunity: could add PRD versioning (store diffs on re-generation for same topic)
- Opportunity: could add a frontend PRD page to the SPA dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)