### PR TITLE
Add monitoring and observability system for hub

### DIFF
--- a/hub/db.py
+++ b/hub/db.py
@@ -153,6 +153,30 @@ CREATE TABLE IF NOT EXISTS qa_checks (
     error TEXT DEFAULT '',
     checked_at TEXT NOT NULL
 );
+
+-- Data source freshness tracking
+CREATE TABLE IF NOT EXISTS data_sources (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    source_name TEXT NOT NULL UNIQUE,
+    last_run_at TEXT,
+    last_success_at TEXT,
+    last_error TEXT DEFAULT '',
+    items_collected INTEGER DEFAULT 0,
+    status TEXT DEFAULT 'unknown',  -- healthy, stale, error, unknown
+    expected_interval_hours REAL DEFAULT 24,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+-- Event log for monitoring
+CREATE TABLE IF NOT EXISTS event_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_type TEXT NOT NULL,       -- collection, error, qa_check, worker_start, worker_complete, alert, heartbeat
+    source TEXT DEFAULT '',
+    message TEXT NOT NULL,
+    details TEXT DEFAULT '{}',      -- JSON blob
+    created_at TEXT NOT NULL
+);
 """
 
 
@@ -511,6 +535,103 @@ def set_cached_kpi(key: str, value) -> None:
             "INSERT OR REPLACE INTO kpi_cache (key, value, fetched_at) VALUES (?, ?, ?)",
             (key, json.dumps(value, default=str), now_iso()),
         )
+
+
+# --- Data Sources (Monitoring) ---
+
+def upsert_data_source(source_name: str, status: str = "unknown",
+                       last_error: str = "", items_collected: int = 0,
+                       expected_interval_hours: float = 24) -> int:
+    """Create or update a data source entry."""
+    ts = now_iso()
+    with get_db() as conn:
+        existing = conn.execute(
+            "SELECT id FROM data_sources WHERE source_name = ?", (source_name,)
+        ).fetchone()
+        if existing:
+            conn.execute(
+                """UPDATE data_sources SET status = ?, last_run_at = ?, last_error = ?,
+                   items_collected = ?, updated_at = ?
+                   WHERE source_name = ?""",
+                (status, ts, last_error, items_collected, ts, source_name)
+            )
+            if status == "healthy":
+                conn.execute(
+                    "UPDATE data_sources SET last_success_at = ? WHERE source_name = ?",
+                    (ts, source_name)
+                )
+            return existing["id"]
+        else:
+            cur = conn.execute(
+                """INSERT INTO data_sources (source_name, last_run_at, last_success_at, last_error,
+                   items_collected, status, expected_interval_hours, created_at, updated_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (source_name, ts, ts if status == "healthy" else None, last_error,
+                 items_collected, status, expected_interval_hours, ts, ts)
+            )
+            return cur.lastrowid
+
+
+def get_data_sources() -> list:
+    with get_db() as conn:
+        return [dict(r) for r in conn.execute(
+            "SELECT * FROM data_sources ORDER BY source_name").fetchall()]
+
+
+def get_data_source(source_name: str):
+    with get_db() as conn:
+        row = conn.execute(
+            "SELECT * FROM data_sources WHERE source_name = ?", (source_name,)
+        ).fetchone()
+        return dict(row) if row else None
+
+
+def update_data_source_status(source_name: str, status: str):
+    with get_db() as conn:
+        conn.execute(
+            "UPDATE data_sources SET status = ?, updated_at = ? WHERE source_name = ?",
+            (status, now_iso(), source_name)
+        )
+
+
+# --- Event Log (Monitoring) ---
+
+def log_event(event_type: str, message: str, source: str = "",
+              details: dict = None) -> int:
+    with get_db() as conn:
+        cur = conn.execute(
+            """INSERT INTO event_log (event_type, source, message, details, created_at)
+               VALUES (?, ?, ?, ?, ?)""",
+            (event_type, source, message, json.dumps(details or {}), now_iso())
+        )
+        return cur.lastrowid
+
+
+def get_event_log(limit: int = 100, event_type: str = None) -> list:
+    with get_db() as conn:
+        query = "SELECT * FROM event_log WHERE 1=1"
+        params = []
+        if event_type:
+            query += " AND event_type = ?"
+            params.append(event_type)
+        query += " ORDER BY created_at DESC LIMIT ?"
+        params.append(limit)
+        return [dict(r) for r in conn.execute(query, params).fetchall()]
+
+
+def get_table_row_counts() -> dict:
+    """Return row counts for all tables."""
+    tables = ["work_items", "learnings", "data_verifications", "feedback",
+              "experiments", "oem_snapshots", "gracenote_mappings", "query_history",
+              "change_log", "kpi_cache", "data_sources", "event_log"]
+    counts = {}
+    with get_db() as conn:
+        for t in tables:
+            try:
+                counts[t] = conn.execute(f"SELECT COUNT(*) FROM {t}").fetchone()[0]
+            except Exception:
+                counts[t] = 0
+    return counts
 
 
 # Initialize on import

--- a/hub/monitoring.py
+++ b/hub/monitoring.py
@@ -1,0 +1,153 @@
+"""Background monitoring: freshness checks and staleness alerting."""
+
+import threading
+import time
+from datetime import datetime, timedelta
+
+from . import db
+
+# Expected refresh intervals per source (hours)
+DEFAULT_INTERVALS = {
+    "databricks": 2,
+    "reddit": 6,
+    "appstore": 12,
+    "sprout_social": 12,
+    "intel_scan": 24,
+}
+
+_checker_thread = None
+_stop_event = threading.Event()
+_start_time = None
+
+
+def get_uptime_seconds() -> float:
+    if _start_time is None:
+        return 0
+    return (datetime.now() - _start_time).total_seconds()
+
+
+def ensure_default_sources():
+    """Seed data_sources table with known sources if they don't exist."""
+    for name, interval in DEFAULT_INTERVALS.items():
+        existing = db.get_data_source(name)
+        if not existing:
+            db.upsert_data_source(
+                source_name=name,
+                status="unknown",
+                expected_interval_hours=interval,
+            )
+
+
+def check_freshness():
+    """Check all sources for staleness. Returns list of stale source names."""
+    sources = db.get_data_sources()
+    stale_sources = []
+    now = datetime.now()
+
+    for src in sources:
+        name = src["source_name"]
+        interval_hours = src["expected_interval_hours"] or DEFAULT_INTERVALS.get(name, 24)
+        last_success = src["last_success_at"]
+
+        if not last_success:
+            # Never collected — mark stale if source has been registered for > interval
+            created = datetime.fromisoformat(src["created_at"])
+            if (now - created).total_seconds() > interval_hours * 3600:
+                db.update_data_source_status(name, "stale")
+                stale_sources.append(name)
+            continue
+
+        last_ts = datetime.fromisoformat(last_success)
+        age_hours = (now - last_ts).total_seconds() / 3600
+
+        if src["status"] == "error":
+            stale_sources.append(name)
+            continue
+
+        if age_hours > interval_hours:
+            db.update_data_source_status(name, "stale")
+            stale_sources.append(name)
+        else:
+            db.update_data_source_status(name, "healthy")
+
+    return stale_sources
+
+
+def _create_staleness_alert(source_name: str):
+    """Create a work item alert for a stale source, avoiding duplicates."""
+    title = f"[ALERT] Data source '{source_name}' is stale"
+    # Check for existing open alert
+    existing = db.get_work_items(status="open", type="alert", limit=500)
+    for item in existing:
+        if item["title"] == title:
+            return  # Already exists
+
+    src = db.get_data_source(source_name)
+    last_success = src["last_success_at"] or "never"
+    interval = src["expected_interval_hours"] or DEFAULT_INTERVALS.get(source_name, 24)
+    description = (
+        f"Data source '{source_name}' has not been refreshed within its expected interval.\n"
+        f"Expected interval: {interval}h\n"
+        f"Last success: {last_success}\n"
+        f"Last error: {src.get('last_error', 'none')}"
+    )
+    db.create_work_item(
+        type="alert",
+        title=title,
+        description=description,
+        priority="high",
+        tags=["monitoring", "staleness", source_name],
+    )
+    db.log_event(
+        event_type="alert",
+        source=source_name,
+        message=f"Staleness alert created for '{source_name}'",
+        details={"last_success_at": last_success, "interval_hours": interval},
+    )
+
+
+def _checker_loop(interval_seconds: int = 1800):
+    """Background loop: check freshness every interval_seconds (default 30 min)."""
+    while not _stop_event.is_set():
+        try:
+            stale = check_freshness()
+            for name in stale:
+                _create_staleness_alert(name)
+            if stale:
+                db.log_event(
+                    event_type="freshness_check",
+                    message=f"Freshness check found {len(stale)} stale source(s): {', '.join(stale)}",
+                )
+            else:
+                db.log_event(
+                    event_type="freshness_check",
+                    message="Freshness check: all sources healthy",
+                )
+        except Exception as e:
+            db.log_event(
+                event_type="error",
+                message=f"Freshness checker error: {e}",
+            )
+        _stop_event.wait(interval_seconds)
+
+
+def start_checker(interval_seconds: int = 1800):
+    """Start the background freshness checker thread."""
+    global _checker_thread, _start_time
+    _start_time = datetime.now()
+    _stop_event.clear()
+    ensure_default_sources()
+    _checker_thread = threading.Thread(
+        target=_checker_loop,
+        args=(interval_seconds,),
+        daemon=True,
+        name="freshness-checker",
+    )
+    _checker_thread.start()
+
+
+def stop_checker():
+    """Stop the background freshness checker."""
+    _stop_event.set()
+    if _checker_thread:
+        _checker_thread.join(timeout=5)

--- a/hub/routers/dashboard.py
+++ b/hub/routers/dashboard.py
@@ -276,7 +276,21 @@ def get_overview():
     # QA status indicator
     qa_status = _get_qa_status()
 
+    # Monitor summary
+    sources = db.get_data_sources()
+    sources_healthy = sum(1 for s in sources if s["status"] == "healthy")
+    sources_stale = sum(1 for s in sources if s["status"] == "stale")
+    sources_error = sum(1 for s in sources if s["status"] == "error")
+    alert_items = [w for w in work_items if w["type"] == "alert" and w["status"] == "open"]
+
     return {
+        "monitor": {
+            "sources_total": len(sources),
+            "sources_healthy": sources_healthy,
+            "sources_stale": sources_stale,
+            "sources_error": sources_error,
+            "open_alerts": len(alert_items),
+        },
         "kpis": kpis,
         "daily_trend": trend_data,
         "top_channels": channels_data,

--- a/hub/routers/monitor.py
+++ b/hub/routers/monitor.py
@@ -1,0 +1,150 @@
+"""Monitoring router: health, sources, events, heartbeats."""
+
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from .. import db
+from ..config import DATA_DIR
+from ..monitoring import check_freshness, get_uptime_seconds
+
+router = APIRouter(prefix="/api/monitor", tags=["monitor"])
+
+
+class HeartbeatRequest(BaseModel):
+    source: str
+    items_collected: int = 0
+    error: str = ""
+
+
+class EventRequest(BaseModel):
+    event_type: str
+    source: str = ""
+    message: str
+    details: dict = {}
+
+
+def _disk_usage(path: Path) -> dict:
+    """Get disk usage for a directory in bytes."""
+    total = 0
+    file_count = 0
+    if path.exists():
+        for f in path.rglob("*"):
+            if f.is_file():
+                total += f.stat().st_size
+                file_count += 1
+    return {"bytes": total, "mb": round(total / (1024 * 1024), 2), "files": file_count}
+
+
+@router.get("/health")
+def get_health():
+    """Overall system health: sources, uptime, row counts, disk usage."""
+    sources = db.get_data_sources()
+    healthy = sum(1 for s in sources if s["status"] == "healthy")
+    stale = sum(1 for s in sources if s["status"] == "stale")
+    errored = sum(1 for s in sources if s["status"] == "error")
+
+    row_counts = db.get_table_row_counts()
+
+    # Last QA check (most recent data_verification)
+    verifications = db.get_verifications(limit=1)
+    last_qa = verifications[0] if verifications else None
+
+    return {
+        "status": "degraded" if (stale > 0 or errored > 0) else "healthy",
+        "uptime_seconds": round(get_uptime_seconds(), 1),
+        "sources": {
+            "total": len(sources),
+            "healthy": healthy,
+            "stale": stale,
+            "error": errored,
+        },
+        "row_counts": row_counts,
+        "last_qa_check": {
+            "metric": last_qa["metric_name"] if last_qa else None,
+            "status": last_qa["match_status"] if last_qa else None,
+            "at": last_qa["created_at"] if last_qa else None,
+        },
+        "disk_usage": _disk_usage(DATA_DIR),
+        "checked_at": datetime.now().isoformat(),
+    }
+
+
+@router.get("/sources")
+def get_sources():
+    """Detailed source-by-source freshness with last error messages."""
+    sources = db.get_data_sources()
+    result = []
+    now = datetime.now()
+    for src in sources:
+        last_success = src["last_success_at"]
+        if last_success:
+            age_hours = (now - datetime.fromisoformat(last_success)).total_seconds() / 3600
+        else:
+            age_hours = None
+
+        result.append({
+            "source_name": src["source_name"],
+            "status": src["status"],
+            "last_run_at": src["last_run_at"],
+            "last_success_at": src["last_success_at"],
+            "last_error": src["last_error"],
+            "items_collected": src["items_collected"],
+            "expected_interval_hours": src["expected_interval_hours"],
+            "age_hours": round(age_hours, 1) if age_hours is not None else None,
+            "updated_at": src["updated_at"],
+        })
+    return result
+
+
+@router.get("/log")
+def get_log(limit: int = 100, event_type: Optional[str] = None):
+    """Last N events from the event log."""
+    return db.get_event_log(limit=limit, event_type=event_type)
+
+
+@router.post("/heartbeat")
+def post_heartbeat(req: HeartbeatRequest):
+    """Collectors call this after completing a run."""
+    status = "error" if req.error else "healthy"
+    db.upsert_data_source(
+        source_name=req.source,
+        status=status,
+        last_error=req.error,
+        items_collected=req.items_collected,
+    )
+    db.log_event(
+        event_type="heartbeat",
+        source=req.source,
+        message=f"Heartbeat from '{req.source}': {req.items_collected} items" + (
+            f" (error: {req.error})" if req.error else ""
+        ),
+        details={"items_collected": req.items_collected, "error": req.error},
+    )
+    return {"status": "ok", "source": req.source, "recorded_status": status}
+
+
+@router.post("/event")
+def post_event(req: EventRequest):
+    """Log an arbitrary event (workers call this for start/finish)."""
+    event_id = db.log_event(
+        event_type=req.event_type,
+        source=req.source,
+        message=req.message,
+        details=req.details,
+    )
+    return {"status": "ok", "event_id": event_id}
+
+
+@router.post("/check")
+def trigger_check():
+    """Manually trigger a freshness check."""
+    stale = check_freshness()
+    return {
+        "stale_sources": stale,
+        "checked_at": datetime.now().isoformat(),
+    }

--- a/hub/server.py
+++ b/hub/server.py
@@ -8,6 +8,8 @@ Usage:
 """
 
 import argparse
+import sys
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 import uvicorn
@@ -17,12 +19,22 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
 
 from .config import HUB_PORT, HUB_HOST
-from .routers import dashboard, intel, data, sentiment, features, oem, strategy, search, qa
+from .routers import dashboard, intel, data, sentiment, features, oem, strategy, search, qa, monitor
+from .monitoring import start_checker, stop_checker
+
+
+@asynccontextmanager
+async def lifespan(app):
+    start_checker(interval_seconds=1800)
+    yield
+    stop_checker()
+
 
 app = FastAPI(
     title="Linear Hub",
     description="SSOT for Tubi Linear TV strategy, data, competitive intelligence, and operations",
     version="1.0.0",
+    lifespan=lifespan,
 )
 
 app.add_middleware(
@@ -42,6 +54,7 @@ app.include_router(oem.router)
 app.include_router(strategy.router)
 app.include_router(search.router)
 app.include_router(qa.router)
+app.include_router(monitor.router)
 
 # Static files
 STATIC_DIR = Path(__file__).parent / "static"

--- a/hub/static/index.html
+++ b/hub/static/index.html
@@ -173,6 +173,7 @@ textarea { min-height: 120px; resize: vertical; font-family: 'SF Mono', Menlo, m
     <a class="nav-item" data-page="oem"><span class="icon">&#9635;</span> OEM Tracker</a>
 
     <div class="nav-section">Operations</div>
+    <a class="nav-item" data-page="monitor"><span class="icon">&#9854;</span> Monitor</a>
     <a class="nav-item" data-page="work"><span class="icon">&#9744;</span> Work Queue</a>
     <a class="nav-item" data-page="learnings"><span class="icon">&#9998;</span> Learnings</a>
     <a class="nav-item" data-page="changelog"><span class="icon">&#8635;</span> Changelog</a>
@@ -404,6 +405,29 @@ textarea { min-height: 120px; resize: vertical; font-family: 'SF Mono', Menlo, m
       <div class="card" id="changelog-list" style="max-height:600px;overflow-y:auto"></div>
     </div>
 
+    <!-- MONITOR PAGE -->
+    <div class="page" id="page-monitor">
+      <div class="topbar-actions" style="margin-bottom:16px">
+        <button class="btn btn-primary" onclick="triggerFreshnessCheck()">Check Now</button>
+        <button class="btn" onclick="loadMonitor()">Refresh</button>
+      </div>
+      <div class="grid g4" id="monitor-health-cards"></div>
+      <div class="section-title">Data Source Freshness</div>
+      <div class="card">
+        <div class="table-wrap" id="monitor-sources-table"></div>
+      </div>
+      <div class="grid g2" style="margin-top:16px">
+        <div>
+          <div class="section-title">System Stats</div>
+          <div class="card" id="monitor-stats"></div>
+        </div>
+        <div>
+          <div class="section-title">Event Log <span class="count" id="event-log-count"></span></div>
+          <div class="card" id="monitor-event-log" style="max-height:500px;overflow-y:auto"></div>
+        </div>
+      </div>
+    </div>
+
     <!-- SEARCH PAGE -->
     <div class="page" id="page-search">
       <div class="card" style="margin-bottom:16px">
@@ -451,6 +475,7 @@ function loadPageData(page) {
     work: loadWork,
     learnings: loadLearnings,
     changelog: loadChangelog,
+    monitor: loadMonitor,
   };
   if (loaders[page]) loaders[page]();
 }
@@ -549,12 +574,15 @@ async function loadDashboard() {
 
   // System health
   const scan = overview.latest_scan;
+  const mon = overview.monitor || {};
+  const monStatus = (mon.sources_stale > 0 || mon.sources_error > 0) ? '<span style="color:var(--orange)">degraded</span>' : '<span style="color:var(--green)">healthy</span>';
   document.getElementById('system-health').innerHTML = `
     <div style="font-size:13px">
+      <div style="padding:4px 0">Status: ${monStatus}</div>
+      <div style="padding:4px 0">Sources: <span style="color:var(--green)">${mon.sources_healthy || 0} healthy</span>${mon.sources_stale ? `, <span style="color:var(--orange)">${mon.sources_stale} stale</span>` : ''}${mon.sources_error ? `, <span style="color:var(--red)">${mon.sources_error} error</span>` : ''}</div>
+      ${mon.open_alerts ? `<div style="padding:4px 0;color:var(--orange)">Alerts: ${mon.open_alerts} open</div>` : ''}
       <div style="padding:4px 0">Latest scan: ${scan ? scan.scan_date + '/' + scan.run_id : 'None'}</div>
-      <div style="padding:4px 0">Articles: ${scan?.articles_collected || 0}</div>
-      <div style="padding:4px 0">Threats: ${scan?.threats_found || 0}</div>
-      <div style="padding:4px 0">Reports: ${overview.intel?.reports || 0}</div>
+      <div style="padding:4px 0">Articles: ${scan?.articles_collected || 0} &middot; Reports: ${overview.intel?.reports || 0}</div>
     </div>
   `;
 
@@ -1074,6 +1102,65 @@ async function submitChange() {
     impact: document.getElementById('c-impact').value,
   })});
   hideModal(); loadChangelog();
+}
+
+// --- Monitor ---
+async function loadMonitor() {
+  const [health, sources, log] = await Promise.all([
+    api('/api/monitor/health'),
+    api('/api/monitor/sources'),
+    api('/api/monitor/log?limit=100'),
+  ]);
+
+  // Health cards
+  const s = health.sources || {};
+  const statusColor = health.status === 'healthy' ? 'var(--green)' : 'var(--orange)';
+  const uptimeMin = Math.round((health.uptime_seconds || 0) / 60);
+  const uptimeStr = uptimeMin >= 60 ? `${Math.floor(uptimeMin / 60)}h ${uptimeMin % 60}m` : `${uptimeMin}m`;
+  document.getElementById('monitor-health-cards').innerHTML = [
+    `<div class="card card-sm"><h3>System Status</h3><div class="value" style="color:${statusColor}">${health.status}</div><div class="sub">Uptime: ${uptimeStr}</div></div>`,
+    `<div class="card card-sm"><h3>Sources Healthy</h3><div class="value" style="color:var(--green)">${s.healthy || 0}</div><div class="sub">of ${s.total || 0} sources</div></div>`,
+    `<div class="card card-sm"><h3>Stale</h3><div class="value" style="color:var(--orange)">${s.stale || 0}</div></div>`,
+    `<div class="card card-sm"><h3>Disk Usage</h3><div class="value">${health.disk_usage?.mb || 0}</div><div class="sub">MB (${health.disk_usage?.files || 0} files)</div></div>`,
+  ].join('');
+
+  // Sources table
+  function sourceStatusTag(status) {
+    const colors = { healthy: 'green', stale: 'orange', error: 'red', unknown: 'gray' };
+    return `<span class="tag tag-${colors[status] || 'gray'}">${status}</span>`;
+  }
+  document.getElementById('monitor-sources-table').innerHTML = sources.length ?
+    `<table><thead><tr><th>Source</th><th>Status</th><th>Last Success</th><th>Age</th><th>Interval</th><th>Items</th><th>Last Error</th></tr></thead><tbody>${sources.map(s => {
+      const ageStr = s.age_hours !== null ? `${s.age_hours}h` : 'never';
+      const ageColor = s.age_hours === null ? 'var(--text3)' : s.age_hours > s.expected_interval_hours ? 'var(--red)' : 'var(--green)';
+      return `<tr><td><strong>${s.source_name}</strong></td><td>${sourceStatusTag(s.status)}</td><td style="font-size:11px">${s.last_success_at ? new Date(s.last_success_at).toLocaleString() : 'Never'}</td><td style="color:${ageColor}">${ageStr}</td><td>${s.expected_interval_hours}h</td><td>${s.items_collected}</td><td style="font-size:11px;color:var(--red);max-width:200px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${s.last_error || '—'}</td></tr>`;
+    }).join('')}</tbody></table>` : '<div class="empty">No data sources registered</div>';
+
+  // System stats
+  const rc = health.row_counts || {};
+  document.getElementById('monitor-stats').innerHTML = `
+    <div style="font-size:13px">
+      ${Object.entries(rc).map(([k, v]) => `<div style="display:flex;justify-content:space-between;padding:4px 12px;border-bottom:1px solid var(--border)"><span>${k}</span><span style="color:var(--text2)">${v}</span></div>`).join('')}
+      ${health.last_qa_check?.metric ? `<div style="padding:8px 12px;margin-top:8px;font-size:12px;color:var(--text2)">Last QA: ${health.last_qa_check.metric} — ${statusTag(health.last_qa_check.status)}</div>` : ''}
+    </div>
+  `;
+
+  // Event log
+  document.getElementById('event-log-count').textContent = `(${log.length})`;
+  const typeColors = { heartbeat: 'green', collection: 'blue', error: 'red', alert: 'orange', freshness_check: 'purple', worker_start: 'blue', worker_complete: 'green', qa_check: 'purple' };
+  document.getElementById('monitor-event-log').innerHTML = log.length ? log.map(e =>
+    `<div class="list-item" style="padding:8px 12px"><div style="display:flex;justify-content:space-between;align-items:center"><span class="tag tag-${typeColors[e.event_type] || 'gray'}" style="font-size:10px">${e.event_type}</span><span style="font-size:10px;color:var(--text3)">${new Date(e.created_at).toLocaleString()}</span></div><div style="font-size:12px;margin-top:4px">${e.message}</div>${e.source ? `<div style="font-size:10px;color:var(--text3)">source: ${e.source}</div>` : ''}</div>`
+  ).join('') : '<div class="empty">No events logged yet</div>';
+}
+
+async function triggerFreshnessCheck() {
+  const r = await api('/api/monitor/check', { method: 'POST' });
+  if (r.stale_sources && r.stale_sources.length > 0) {
+    alert('Stale sources found: ' + r.stale_sources.join(', '));
+  } else {
+    alert('All sources healthy');
+  }
+  loadMonitor();
 }
 
 // --- Search ---


### PR DESCRIPTION
## Summary
- Adds data freshness tracking for all 5 data sources (databricks, reddit, appstore, sprout_social, intel_scan) with configurable staleness intervals
- Creates monitoring API with 6 endpoints: health check, source status, event log, heartbeat (for collectors), event logging, and manual freshness check
- Background thread checks source freshness every 30 minutes and auto-creates deduplicated staleness alert work items
- Adds Monitor page to frontend SPA with source freshness table (green/yellow/red), event log, and system stats
- Wires monitor summary into `/api/dashboard/overview` response
- Uses FastAPI lifespan events (no deprecation warnings)
- Resolves merge conflicts with live Databricks dashboard PR (both features preserved)

### New files
- `hub/monitoring.py` — background freshness checker, staleness alerting
- `hub/routers/monitor.py` — 6 API endpoints

### Modified files
- `hub/db.py` — added `data_sources` and `event_log` tables + CRUD functions
- `hub/server.py` — register monitor router, lifespan startup/shutdown
- `hub/routers/dashboard.py` — add `monitor` key to overview response
- `hub/static/index.html` — Monitor nav item + page

### API Endpoints
| Method | Path | Purpose |
|--------|------|---------|
| GET | `/api/monitor/health` | System health, uptime, row counts, disk usage |
| GET | `/api/monitor/sources` | Per-source freshness with age and errors |
| GET | `/api/monitor/log` | Last 100 events |
| POST | `/api/monitor/heartbeat` | Collectors report completion |
| POST | `/api/monitor/event` | Log arbitrary events |
| POST | `/api/monitor/check` | Trigger freshness check |

## Test plan
- [x] All endpoints tested with curl against localhost:8889
- [x] Heartbeat creates/updates source status correctly
- [x] Error heartbeat marks source as error, degrades system health
- [x] Event logging stores and retrieves events
- [x] Freshness check runs without errors
- [x] Dashboard overview includes monitor summary
- [x] Frontend Monitor page renders
- [x] Merge conflict with Databricks live dashboard resolved cleanly

### Future opportunities (not in scope)
- WebSocket push for real-time status updates
- Email/Slack notifications for staleness alerts
- Historical freshness trends chart

🤖 Generated with [Claude Code](https://claude.com/claude-code)