### PR TITLE
Add metadata enrichment layer for feedback signals

### DIFF
--- a/hub/db.py
+++ b/hub/db.py
@@ -274,6 +274,19 @@ CREATE TABLE IF NOT EXISTS problem_links (
     FOREIGN KEY (work_item_id) REFERENCES work_items(id),
     FOREIGN KEY (experiment_id) REFERENCES experiments(id)
 );
+
+-- Feedback enrichments: AI-extracted metadata
+CREATE TABLE IF NOT EXISTS enrichments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    feedback_id INTEGER NOT NULL UNIQUE,
+    entities_json TEXT DEFAULT '{}',
+    user_context_json TEXT DEFAULT '{}',
+    product_areas_json TEXT DEFAULT '[]',
+    actionability_json TEXT DEFAULT '{}',
+    competitive_json TEXT DEFAULT 'null',
+    enriched_at TEXT NOT NULL,
+    FOREIGN KEY (feedback_id) REFERENCES feedback(id)
+);
 """
 
 
@@ -769,12 +782,178 @@ def get_event_log(limit: int = 100, event_type: str = None) -> list:
         return [dict(r) for r in conn.execute(query, params).fetchall()]
 
 
+# --- Enrichments ---
+
+def create_enrichment(feedback_id: int, entities: dict, user_context: dict,
+                      product_areas: list, actionability: dict,
+                      competitive_mention=None) -> int:
+    with get_db() as conn:
+        cur = conn.execute(
+            """INSERT OR REPLACE INTO enrichments
+               (feedback_id, entities_json, user_context_json, product_areas_json,
+                actionability_json, competitive_json, enriched_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (feedback_id, json.dumps(entities), json.dumps(user_context),
+             json.dumps(product_areas), json.dumps(actionability),
+             json.dumps(competitive_mention), now_iso())
+        )
+        return cur.lastrowid
+
+
+def get_enrichment(feedback_id: int) -> dict | None:
+    with get_db() as conn:
+        row = conn.execute(
+            "SELECT * FROM enrichments WHERE feedback_id = ?", (feedback_id,)
+        ).fetchone()
+        if not row:
+            return None
+        d = dict(row)
+        for col in ("entities_json", "user_context_json", "product_areas_json",
+                     "actionability_json", "competitive_json"):
+            if isinstance(d.get(col), str):
+                d[col] = json.loads(d[col])
+        return d
+
+
+def get_unenriched_feedback_ids(limit: int = 500) -> list:
+    """Return feedback IDs that have no enrichment record."""
+    with get_db() as conn:
+        rows = conn.execute(
+            """SELECT f.id FROM feedback f
+               LEFT JOIN enrichments e ON f.id = e.feedback_id
+               WHERE e.id IS NULL
+               ORDER BY f.created_at DESC LIMIT ?""",
+            (limit,)
+        ).fetchall()
+        return [r["id"] for r in rows]
+
+
+def get_feedback_by_id(feedback_id: int) -> dict | None:
+    with get_db() as conn:
+        row = conn.execute("SELECT * FROM feedback WHERE id = ?", (feedback_id,)).fetchone()
+        if not row:
+            return None
+        d = dict(row)
+        if isinstance(d.get("topics"), str):
+            d["topics"] = json.loads(d["topics"])
+        if isinstance(d.get("metadata"), str):
+            d["metadata"] = json.loads(d["metadata"])
+        return d
+
+
+def get_feedback_by_product_area(area: str = None, limit: int = 200) -> list:
+    """Get feedback grouped by product area from enrichments."""
+    with get_db() as conn:
+        rows = conn.execute(
+            """SELECT f.*, e.product_areas_json, e.entities_json, e.actionability_json,
+                      e.user_context_json, e.competitive_json
+               FROM feedback f
+               JOIN enrichments e ON f.id = e.feedback_id
+               ORDER BY f.collected_at DESC LIMIT ?""",
+            (limit,)
+        ).fetchall()
+        results = []
+        for row in rows:
+            d = dict(row)
+            areas = json.loads(d.get("product_areas_json", "[]"))
+            if area and area not in areas:
+                continue
+            for col in ("topics", "metadata"):
+                if isinstance(d.get(col), str):
+                    d[col] = json.loads(d[col])
+            for col in ("product_areas_json", "entities_json", "actionability_json",
+                         "user_context_json", "competitive_json"):
+                if isinstance(d.get(col), str):
+                    d[col] = json.loads(d[col])
+            results.append(d)
+        return results
+
+
+def get_feedback_by_competitor(limit: int = 200) -> list:
+    """Get all feedback with competitive mentions."""
+    with get_db() as conn:
+        rows = conn.execute(
+            """SELECT f.*, e.competitive_json, e.entities_json, e.actionability_json,
+                      e.product_areas_json
+               FROM feedback f
+               JOIN enrichments e ON f.id = e.feedback_id
+               WHERE e.competitive_json IS NOT NULL AND e.competitive_json != 'null'
+               ORDER BY f.collected_at DESC LIMIT ?""",
+            (limit,)
+        ).fetchall()
+        results = []
+        for row in rows:
+            d = dict(row)
+            for col in ("topics", "metadata"):
+                if isinstance(d.get(col), str):
+                    d[col] = json.loads(d[col])
+            for col in ("competitive_json", "entities_json", "actionability_json",
+                         "product_areas_json"):
+                if isinstance(d.get(col), str):
+                    d[col] = json.loads(d[col])
+            results.append(d)
+        return results
+
+
+def get_churn_risks(limit: int = 100) -> list:
+    """Get feedback flagged as churn risk, most recent first."""
+    with get_db() as conn:
+        rows = conn.execute(
+            """SELECT f.*, e.actionability_json, e.entities_json, e.product_areas_json,
+                      e.user_context_json, e.competitive_json
+               FROM feedback f
+               JOIN enrichments e ON f.id = e.feedback_id
+               WHERE json_extract(e.actionability_json, '$.is_churn_risk') = 1
+               ORDER BY f.collected_at DESC LIMIT ?""",
+            (limit,)
+        ).fetchall()
+        results = []
+        for row in rows:
+            d = dict(row)
+            for col in ("topics", "metadata"):
+                if isinstance(d.get(col), str):
+                    d[col] = json.loads(d[col])
+            for col in ("actionability_json", "entities_json", "product_areas_json",
+                         "user_context_json", "competitive_json"):
+                if isinstance(d.get(col), str):
+                    d[col] = json.loads(d[col])
+            results.append(d)
+        return results
+
+
+def get_feature_requests(limit: int = 100) -> list:
+    """Get feedback flagged as feature requests."""
+    with get_db() as conn:
+        rows = conn.execute(
+            """SELECT f.*, e.actionability_json, e.entities_json, e.product_areas_json,
+                      e.user_context_json
+               FROM feedback f
+               JOIN enrichments e ON f.id = e.feedback_id
+               WHERE json_extract(e.actionability_json, '$.is_feature_request') = 1
+               ORDER BY f.collected_at DESC LIMIT ?""",
+            (limit,)
+        ).fetchall()
+        results = []
+        for row in rows:
+            d = dict(row)
+            for col in ("topics", "metadata"):
+                if isinstance(d.get(col), str):
+                    d[col] = json.loads(d[col])
+            for col in ("actionability_json", "entities_json", "product_areas_json",
+                         "user_context_json"):
+                if isinstance(d.get(col), str):
+                    d[col] = json.loads(d[col])
+            results.append(d)
+        return results
+
+
 def get_table_row_counts() -> dict:
     """Return row counts for all tables."""
     tables = ["work_items", "learnings", "data_verifications", "feedback",
               "experiments", "oem_snapshots", "gracenote_mappings", "query_history",
               "change_log", "kpi_cache", "data_sources", "event_log",
-              "prd_reviews", "feature_ideas", "insights"]
+              "prd_reviews", "feature_ideas", "insights", "enrichments",
+              "ai_insights", "problems", "problem_quotes", "problem_links"]
     counts = {}
     with get_db() as conn:
         for t in tables:

--- a/hub/enrichment.py
+++ b/hub/enrichment.py
@@ -1,0 +1,131 @@
+"""Metadata enrichment layer for feedback signals.
+
+Uses OpenAI gpt-4o to extract structured metadata from raw feedback text:
+entities, user context, product areas, actionability, and competitive mentions.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Optional
+
+from openai import OpenAI
+
+from .config import OPENAI_API_KEY
+
+logger = logging.getLogger(__name__)
+
+ENRICHMENT_PROMPT = """\
+You are analyzing user feedback about Tubi, a free ad-supported streaming TV (FAST) service.
+Extract structured metadata from the following feedback text.
+
+Feedback text: {text}
+Source: {source}
+Additional context: {metadata}
+
+Return a JSON object with these exact keys:
+
+{{
+  "entities": {{
+    "channels": [],
+    "platforms": [],
+    "features": [],
+    "competitors": []
+  }},
+  "user_context": {{
+    "is_new_user": false,
+    "is_power_user": false,
+    "device_mentioned": "",
+    "usage_pattern": ""
+  }},
+  "product_areas": [],
+  "actionability": {{
+    "is_feature_request": false,
+    "is_bug_report": false,
+    "is_churn_risk": false,
+    "is_praise": false,
+    "suggested_fix": ""
+  }},
+  "competitive_mention": null
+}}
+
+Rules:
+- "channels": specific channel names mentioned (e.g., "ION", "Dateline 24/7", "NBC News NOW")
+- "platforms": devices/platforms mentioned (e.g., "Roku", "Fire TV", "Samsung TV", "iOS", "Android")
+- "features": UI/product features mentioned (e.g., "EPG grid", "search", "On Now row", "favorites")
+- "competitors": competitor services mentioned (e.g., "Pluto TV", "YouTube TV", "Roku Channel", "Xumo")
+- "product_areas": list from ONLY these values: "epg_grid", "channel_switching", "on_now_row", "search", "ad_breaks", "content_quality", "app_performance", "deeplinks", "live_tv", "vod", "recommendations", "ui_navigation", "playback", "account", "notifications", "guide", "remote_control", "casting", "subtitles", "audio"
+- "is_new_user": true if text suggests the user recently started using Tubi
+- "is_power_user": true if text suggests heavy/daily usage
+- "device_mentioned": the specific device if mentioned, empty string if not
+- "usage_pattern": brief description of how they use the service (e.g., "daily linear viewer", "occasional VOD watcher")
+- "is_churn_risk": true if user expresses intent to leave, frustration suggesting abandonment, or comparison favoring a competitor
+- "competitive_mention": set to {{"competitor": "name", "comparison": "better"|"worse"|"same", "feature_compared": "what"}} if a competitor is directly compared to Tubi, otherwise null
+
+Return ONLY the JSON object, no markdown formatting or explanation."""
+
+
+def enrich_feedback(text: str, source: str = "", metadata: Optional[dict] = None) -> dict:
+    """Extract rich metadata from feedback text using OpenAI gpt-4o.
+
+    Args:
+        text: The raw feedback text.
+        source: Where the feedback came from (reddit, appstore, etc.).
+        metadata: Any additional context about the feedback.
+
+    Returns:
+        Dict with keys: entities, user_context, product_areas, actionability, competitive_mention.
+        Returns a default/empty structure if OpenAI is unavailable or fails.
+    """
+    default = {
+        "entities": {"channels": [], "platforms": [], "features": [], "competitors": []},
+        "user_context": {"is_new_user": False, "is_power_user": False, "device_mentioned": "", "usage_pattern": ""},
+        "product_areas": [],
+        "actionability": {"is_feature_request": False, "is_bug_report": False, "is_churn_risk": False, "is_praise": False, "suggested_fix": ""},
+        "competitive_mention": None,
+    }
+
+    if not OPENAI_API_KEY:
+        logger.warning("OPENAI_API_KEY not configured, returning default enrichment")
+        return default
+
+    if not text or not text.strip():
+        return default
+
+    try:
+        client = OpenAI(api_key=OPENAI_API_KEY)
+        prompt = ENRICHMENT_PROMPT.format(
+            text=text,
+            source=source,
+            metadata=json.dumps(metadata or {}),
+        )
+        response = client.chat.completions.create(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.1,
+            max_tokens=1000,
+        )
+        content = response.choices[0].message.content.strip()
+        # Strip markdown code fences if present
+        if content.startswith("```"):
+            content = content.split("\n", 1)[1] if "\n" in content else content[3:]
+            if content.endswith("```"):
+                content = content[:-3]
+            content = content.strip()
+
+        result = json.loads(content)
+
+        # Validate and fill missing keys with defaults
+        for key in default:
+            if key not in result:
+                result[key] = default[key]
+
+        return result
+
+    except json.JSONDecodeError as e:
+        logger.error("Failed to parse enrichment JSON: %s", e)
+        return default
+    except Exception as e:
+        logger.error("Enrichment failed: %s", e)
+        return default


### PR DESCRIPTION
## Summary
- **New `hub/enrichment.py`**: Uses OpenAI gpt-4o to extract structured metadata from raw feedback text — entities (channels, platforms, features, competitors), user context (new/power user, device, usage pattern), product areas, actionability flags (feature request, bug report, churn risk, praise), and competitive comparisons
- **New `enrichments` DB table** with query functions for by-feature, by-competitor, churn-risks, and feature-requests views
- **Auto-enrichment on ingest**: Every new feedback item is enriched via background task; `POST /api/sentiment/enrich-all` backfills existing items
- **4 new enrichment-powered query endpoints**: `GET /api/sentiment/by-feature`, `by-competitor`, `churn-risks`, `feature-requests`
- **Frontend detail panel**: Click any feedback item to see all extracted metadata; dropdown switcher for enrichment views

## New Endpoints
| Method | Path | Description |
|--------|------|-------------|
| POST | `/api/sentiment/enrich-all` | Batch enrich all unenriched feedback |
| GET | `/api/sentiment/enrichment/{id}` | Get enrichment for a specific item |
| GET | `/api/sentiment/by-feature` | Feedback grouped by product area |
| GET | `/api/sentiment/by-competitor` | Feedback mentioning competitors |
| GET | `/api/sentiment/churn-risks` | Churn risk flagged feedback |
| GET | `/api/sentiment/feature-requests` | Feature requests grouped by theme |

## Test plan
- [x] Python syntax validation passes for all modified files
- [x] Existing 102 API tests still pass (8 pre-existing Sprout failures unchanged)
- [ ] Verify enrichment with OPENAI_API_KEY set: `curl -X POST localhost:8888/api/sentiment/enrich-all`
- [ ] Verify by-feature endpoint: `curl localhost:8888/api/sentiment/by-feature`
- [ ] Verify churn-risks endpoint: `curl localhost:8888/api/sentiment/churn-risks`
- [ ] Click feedback item in UI to verify detail panel renders

## Notes
- Enrichment degrades gracefully: returns empty defaults when OPENAI_API_KEY is not set
- Background tasks prevent enrichment from blocking feedback creation latency
- Opportunity: Could add enrichment stats to the dashboard overview cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)