### PR TITLE
Fix hub server robustness: graceful router imports

### DIFF
--- a/hub/server.py
+++ b/hub/server.py
@@ -8,6 +8,7 @@ Usage:
 """
 
 import argparse
+import logging
 import sys
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -19,15 +20,41 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
 
 from .config import HUB_PORT, HUB_HOST
-from .routers import dashboard, intel, data, sentiment, features, oem, strategy, search, qa, monitor, knowledge
 from .monitoring import start_checker, stop_checker
+
+logger = logging.getLogger(__name__)
+
+# Import routers gracefully — missing routers (from unmerged PRs) should not
+# crash the entire server.
+_ROUTER_NAMES = [
+    "dashboard", "intel", "data", "sentiment", "features", "oem",
+    "strategy", "search", "qa", "monitor", "knowledge",
+    "insights", "ask", "problems",
+]
+_routers = {}
+for _name in _ROUTER_NAMES:
+    try:
+        _mod = __import__(f"hub.routers.{_name}", fromlist=["router"])
+        _routers[_name] = _mod.router
+    except (ImportError, AttributeError) as e:
+        logger.warning("Router %r unavailable, skipping: %s", _name, e)
 
 
 @asynccontextmanager
 async def lifespan(app):
     start_checker(interval_seconds=1800)
+    try:
+        from .qa.runner import start_scheduler
+        start_scheduler()
+    except Exception as e:
+        logger.warning("QA scheduler failed to start: %s", e)
     yield
     stop_checker()
+    try:
+        from .qa.runner import stop_scheduler
+        stop_scheduler()
+    except Exception as e:
+        logger.warning("QA scheduler failed to stop: %s", e)
 
 
 app = FastAPI(
@@ -44,35 +71,12 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# Mount routers
-app.include_router(dashboard.router)
-app.include_router(intel.router)
-app.include_router(data.router)
-app.include_router(sentiment.router)
-app.include_router(features.router)
-app.include_router(oem.router)
-app.include_router(strategy.router)
-app.include_router(search.router)
-app.include_router(qa.router)
-app.include_router(monitor.router)
-app.include_router(knowledge.router)
+# Mount available routers
+for _name, _router in _routers.items():
+    app.include_router(_router)
 
 # Static files
 STATIC_DIR = Path(__file__).parent / "static"
-
-
-@app.on_event("startup")
-def startup_event():
-    """Start background services on server boot."""
-    from .qa.runner import start_scheduler
-    start_scheduler()
-
-
-@app.on_event("shutdown")
-def shutdown_event():
-    """Stop background services on server shutdown."""
-    from .qa.runner import stop_scheduler
-    stop_scheduler()
 
 
 @app.get("/")


### PR DESCRIPTION
## Summary
- Router imports in `hub/server.py` now use try/except, so missing routers (e.g. `insights`, `ask`, `problems` from unmerged PRs) are skipped gracefully instead of crashing the entire server
- Consolidated deprecated `@app.on_event("startup")`/`@app.on_event("shutdown")` handlers into the existing `lifespan` context manager, eliminating DeprecationWarnings
- QA scheduler start/stop wrapped in try/except within lifespan to prevent startup failures from blocking the server

## Test plan
- [x] Server starts cleanly with missing routers logged as warnings
- [x] `GET /health` → 200
- [x] `POST /api/sentiment/feedback` → 200
- [x] `GET /api/dashboard/overview` → 200
- [x] `GET /api/strategy/learnings` → 200
- [x] `GET /api/strategy/work` → 200
- [x] `GET /api/features/experiments` → 200

## Notes
- The `insights`, `ask`, `problems` routers don't exist yet but are pre-registered so they'll auto-mount when their PRs merge
- No deprecation warnings in server output anymore

🤖 Generated with [Claude Code](https://claude.com/claude-code)