### PR TITLE
Complete Intel Monitor page end-to-end

### DIFF
--- a/hub/db.py
+++ b/hub/db.py
@@ -806,7 +806,7 @@ def create_enrichment(feedback_id: int, entities: dict, user_context: dict,
         return cur.lastrowid
 
 
-def get_enrichment(feedback_id: int) -> dict | None:
+def get_enrichment(feedback_id: int) -> "dict | None":
     with get_db() as conn:
         row = conn.execute(
             "SELECT * FROM enrichments WHERE feedback_id = ?", (feedback_id,)
@@ -834,7 +834,7 @@ def get_unenriched_feedback_ids(limit: int = 500) -> list:
         return [r["id"] for r in rows]
 
 
-def get_feedback_by_id(feedback_id: int) -> dict | None:
+def get_feedback_by_id(feedback_id: int) -> "dict | None":
     with get_db() as conn:
         row = conn.execute("SELECT * FROM feedback WHERE id = ?", (feedback_id,)).fetchone()
         if not row:

--- a/hub/routers/ask.py
+++ b/hub/routers/ask.py
@@ -95,7 +95,7 @@ class AskResponse(BaseModel):
     error: str = ""
 
 
-def _validate_sql(sql: str) -> str | None:
+def _validate_sql(sql: str) -> "str | None":
     """Validate that SQL is SELECT-only. Returns error message or None if valid."""
     stripped = sql.strip().rstrip(";").strip()
     if not stripped.upper().startswith("SELECT") and not stripped.upper().startswith("WITH"):

--- a/hub/routers/intel.py
+++ b/hub/routers/intel.py
@@ -26,6 +26,9 @@ def _load_run_data(scan_date: str, run_id: str) -> dict:
                 data[name] = json.load(f)
     if "classified" in data and "intel" not in data.get("classified", {}):
         data["classified"]["intel"] = data["classified"].get("filtered", [])
+    # Normalize articles — may be {articles: [...]} or [...]
+    if "articles" in data and isinstance(data["articles"], dict):
+        data["articles"] = data["articles"].get("articles", [])
     report_path = run_dir / "report.md"
     if report_path.exists():
         data["report_md"] = report_path.read_text()
@@ -61,18 +64,79 @@ def get_run(scan_date: str, run_id: str):
     return _load_run_data(scan_date, run_id)
 
 
-@router.get("/latest")
-def get_latest():
-    """Get the latest scan run data."""
+def _find_best_run() -> "dict | None":
+    """Find the best run by merging data across recent runs.
+
+    The latest run may not have all data (e.g. classified intel or analysis).
+    This finds the most recent run with analysis data and merges classified
+    data from the best available source.
+    """
     if not SCANS_DIR.exists():
-        return {"error": "No scan data found"}
+        return None
+
+    all_runs = []
     for date_dir in sorted(SCANS_DIR.iterdir(), reverse=True):
         if not date_dir.is_dir():
             continue
         for run_dir in sorted(date_dir.iterdir(), reverse=True):
             if run_dir.is_dir() and (run_dir / "run.json").exists():
-                return _load_run_data(date_dir.name, run_dir.name)
-    return {"error": "No scan data found"}
+                all_runs.append((date_dir.name, run_dir.name))
+    if not all_runs:
+        return None
+
+    # Find the best run with analysis
+    best_analysis_run = None
+    best_classified_run = None
+    best_articles_run = None
+
+    for scan_date, run_id in all_runs:
+        run_dir = SCANS_DIR / scan_date / run_id
+        if not best_analysis_run and (run_dir / "analysis.json").exists():
+            best_analysis_run = (scan_date, run_id)
+        if not best_classified_run:
+            cp = run_dir / "classified.json"
+            if cp.exists():
+                with open(cp) as f:
+                    cd = json.load(f)
+                if cd.get("filtered") or cd.get("all_classified"):
+                    best_classified_run = (scan_date, run_id)
+        if not best_articles_run:
+            ap = run_dir / "articles.json"
+            if ap.exists():
+                best_articles_run = (scan_date, run_id)
+        if best_analysis_run and best_classified_run and best_articles_run:
+            break
+
+    # Use the most recent run as base, then enrich
+    base_date, base_id = all_runs[0]
+    data = _load_run_data(base_date, base_id)
+
+    # Merge analysis from best source if base doesn't have it
+    if "analysis" not in data and best_analysis_run:
+        ad = SCANS_DIR / best_analysis_run[0] / best_analysis_run[1] / "analysis.json"
+        with open(ad) as f:
+            data["analysis"] = json.load(f)
+        data["analysis_source_run"] = best_analysis_run[1]
+
+    # Merge classified from best source if base doesn't have it
+    classified = data.get("classified", {})
+    if not classified.get("filtered") and not classified.get("intel") and best_classified_run:
+        cp = SCANS_DIR / best_classified_run[0] / best_classified_run[1] / "classified.json"
+        with open(cp) as f:
+            data["classified"] = json.load(f)
+        data["classified"]["intel"] = data["classified"].get("filtered", [])
+        data["classified_source_run"] = best_classified_run[1]
+
+    return data
+
+
+@router.get("/latest")
+def get_latest():
+    """Get the latest scan run data, merging from best available sources."""
+    data = _find_best_run()
+    if not data:
+        return {"error": "No scan data found"}
+    return data
 
 
 @router.get("/threats")
@@ -80,7 +144,10 @@ def get_threats():
     """Get all threats from latest analysis."""
     data = get_latest()
     analysis = data.get("analysis", {})
-    return analysis.get("threats", [])
+    threats_data = analysis.get("threats", {})
+    if isinstance(threats_data, dict):
+        return threats_data.get("threats", [])
+    return threats_data
 
 
 @router.get("/opportunities")
@@ -88,7 +155,10 @@ def get_opportunities():
     """Get all opportunities from latest analysis."""
     data = get_latest()
     analysis = data.get("analysis", {})
-    return analysis.get("opportunities", [])
+    opps_data = analysis.get("opportunities", {})
+    if isinstance(opps_data, dict):
+        return opps_data.get("opportunities", [])
+    return opps_data
 
 
 @router.get("/trends")
@@ -96,7 +166,10 @@ def get_trends():
     """Get all trends from latest analysis."""
     data = get_latest()
     analysis = data.get("analysis", {})
-    return analysis.get("trends", [])
+    trends_data = analysis.get("trends", {})
+    if isinstance(trends_data, dict):
+        return trends_data.get("trends", [])
+    return trends_data
 
 
 @router.get("/competitors")
@@ -104,7 +177,10 @@ def get_competitors():
     """Get competitor profiles from latest analysis."""
     data = get_latest()
     analysis = data.get("analysis", {})
-    return analysis.get("profiles", [])
+    profiles_data = analysis.get("profiles", {})
+    if isinstance(profiles_data, dict):
+        return profiles_data.get("profiles", [])
+    return profiles_data
 
 
 def _get_sorted_runs() -> list[dict]:
@@ -255,23 +331,166 @@ def ingest_run(scan_date: str, run_id: str):
     return {"status": "ingested", **result}
 
 
+@router.post("/ensure-work-items")
+def ensure_work_items():
+    """Ensure latest threats/opportunities exist as work items.
+
+    Checks if work items already exist for the latest scan's threats and
+    opportunities. Creates any that are missing. Idempotent.
+    """
+    data = _find_best_run()
+    if not data or "analysis" not in data:
+        return {"status": "no_analysis", "created": 0}
+
+    analysis = data["analysis"]
+    created = 0
+
+    # Get existing work item titles to avoid duplicates
+    existing = db.get_work_items(limit=500)
+    existing_titles = {w["title"] for w in existing}
+
+    # Threats
+    threats_data = analysis.get("threats", {})
+    threats = threats_data.get("threats", []) if isinstance(threats_data, dict) else []
+    for threat in threats:
+        title = threat.get("title") or threat.get("description", "")[:80]
+        if title in existing_titles:
+            continue
+        description = threat.get("description", "")
+        if threat.get("defensive_action"):
+            description += f"\n\nDefensive action: {threat['defensive_action']}"
+        metadata = {
+            "source": "ci_scan",
+            "scan_date": data.get("scan_date", ""),
+            "threat_type": threat.get("threat_type", ""),
+            "severity": threat.get("severity", 0),
+            "timeframe": threat.get("timeframe", ""),
+            "source_competitor": threat.get("source_competitor", ""),
+        }
+        db.create_work_item(
+            type="threat",
+            title=title,
+            description=description,
+            priority="high",
+            tags=["ci_scan", "threat"],
+            metadata=metadata,
+        )
+        existing_titles.add(title)
+        created += 1
+
+    # Opportunities
+    opps_data = analysis.get("opportunities", {})
+    opps = opps_data.get("opportunities", []) if isinstance(opps_data, dict) else []
+    for opp in opps:
+        title = opp.get("title") or opp.get("description", "")[:80]
+        if title in existing_titles:
+            continue
+        description = opp.get("description", "")
+        if opp.get("action_items"):
+            description += "\n\nAction items:\n" + "\n".join(f"- {a}" for a in opp["action_items"])
+        potential = opp.get("potential_value", 0)
+        feasibility = opp.get("feasibility", 0)
+        priority = "high" if (potential * feasibility) > 40 else "medium"
+        metadata = {
+            "source": "ci_scan",
+            "scan_date": data.get("scan_date", ""),
+            "opportunity_type": opp.get("opportunity_type", ""),
+            "potential_value": potential,
+            "feasibility": feasibility,
+            "competitor_gap": opp.get("competitor_gap", ""),
+        }
+        db.create_work_item(
+            type="opportunity",
+            title=title,
+            description=description,
+            priority=priority,
+            tags=["ci_scan", "opportunity"],
+            metadata=metadata,
+        )
+        existing_titles.add(title)
+        created += 1
+
+    return {"status": "ok", "created": created, "threats": len(threats), "opportunities": len(opps)}
+
+
 @router.get("/history")
 def scan_history():
-    """List all past scan runs with article count, threat count, and date."""
+    """List all past scan runs with article count, threat count, and date.
+
+    Reads actual file contents to get accurate counts since run.json
+    metadata may not always be updated.
+    """
     history = []
     for run in _get_sorted_runs():
         run_dir = SCANS_DIR / run["date"] / run["run_id"]
+
+        # Get counts from actual files when run.json shows 0
+        article_count = run.get("articles_collected", 0)
+        classified_count = run.get("articles_classified", 0)
+        threat_count = run.get("threats_found", 0)
+        opp_count = run.get("opportunities_found", 0)
+        trend_count = run.get("trends_identified", 0)
+
+        # Read articles file for accurate count
+        if article_count == 0:
+            articles_path = run_dir / "articles.json"
+            if articles_path.exists():
+                try:
+                    with open(articles_path) as f:
+                        articles = json.load(f)
+                    if isinstance(articles, list):
+                        article_count = len(articles)
+                    elif isinstance(articles, dict):
+                        article_count = len(articles.get("articles", []))
+                except Exception:
+                    pass
+
+        # Read classified file for count
+        if classified_count == 0:
+            classified_path = run_dir / "classified.json"
+            if classified_path.exists():
+                try:
+                    with open(classified_path) as f:
+                        classified = json.load(f)
+                    classified_count = len(classified.get("filtered", [])) or len(classified.get("all_classified", []))
+                except Exception:
+                    pass
+
+        # Read analysis for threat/opp/trend counts
+        if threat_count == 0 or opp_count == 0 or trend_count == 0:
+            analysis_path = run_dir / "analysis.json"
+            if analysis_path.exists():
+                try:
+                    with open(analysis_path) as f:
+                        analysis = json.load(f)
+                    threats_data = analysis.get("threats", {})
+                    if isinstance(threats_data, dict):
+                        threat_count = len(threats_data.get("threats", []))
+                    opps_data = analysis.get("opportunities", {})
+                    if isinstance(opps_data, dict):
+                        opp_count = len(opps_data.get("opportunities", []))
+                    trends_data = analysis.get("trends", {})
+                    if isinstance(trends_data, dict):
+                        trend_count = len(trends_data.get("trends", []))
+                except Exception:
+                    pass
+
+        has_analysis = (run_dir / "analysis.json").exists()
+        has_classified = classified_count > 0
+
         entry = {
             "date": run["date"],
             "run_id": run["run_id"],
             "started_at": run.get("started_at", ""),
             "finished_at": run.get("finished_at", ""),
             "status": run.get("status", "unknown"),
-            "article_count": run.get("articles_collected", 0),
-            "classified_count": run.get("articles_classified", 0),
-            "threat_count": run.get("threats_found", 0),
-            "opportunity_count": run.get("opportunities_found", 0),
-            "trend_count": run.get("trends_identified", 0),
+            "article_count": article_count,
+            "classified_count": classified_count,
+            "threat_count": threat_count,
+            "opportunity_count": opp_count,
+            "trend_count": trend_count,
+            "has_analysis": has_analysis,
+            "has_classified": has_classified,
         }
         history.append(entry)
     return history

--- a/hub/static/index.html
+++ b/hub/static/index.html
@@ -305,24 +305,45 @@ textarea { min-height: 120px; resize: vertical; font-family: 'SF Mono', Menlo, m
     <!-- INTEL MONITOR PAGE -->
     <div class="page" id="page-intel">
       <div class="topbar-actions" style="margin-bottom:16px">
-        <button class="btn btn-primary" onclick="triggerScan()">Run Scan</button>
+        <button class="btn btn-primary" onclick="triggerScan()">Run New Scan</button>
         <button class="btn" onclick="loadIntel()">Refresh</button>
+        <span id="intel-scan-note" style="font-size:11px;color:var(--text3);line-height:32px;margin-left:8px"></span>
       </div>
-      <div class="grid g3" id="intel-stats"></div>
-      <div class="grid g2">
-        <div>
-          <div class="section-title">Threats</div>
-          <div class="card" id="threats-list"></div>
-        </div>
-        <div>
-          <div class="section-title">Opportunities</div>
-          <div class="card" id="opps-list"></div>
-        </div>
+
+      <!-- Latest Scan Summary Card -->
+      <div class="card" id="intel-summary" style="margin-bottom:16px"></div>
+
+      <!-- Stats row -->
+      <div class="grid g4" id="intel-stats"></div>
+
+      <!-- Threats -->
+      <div class="section-title">Threats <span class="count" id="threats-count"></span></div>
+      <div id="threats-grid" style="display:grid;grid-template-columns:repeat(auto-fill,minmax(350px,1fr));gap:12px;margin-bottom:24px"></div>
+
+      <!-- Opportunities -->
+      <div class="section-title">Opportunities <span class="count" id="opps-count"></span></div>
+      <div id="opps-grid" style="display:grid;grid-template-columns:repeat(auto-fill,minmax(350px,1fr));gap:12px;margin-bottom:24px"></div>
+
+      <!-- Trends -->
+      <div class="section-title">Trends <span class="count" id="trends-count"></span></div>
+      <div class="card" id="trends-list" style="margin-bottom:24px"></div>
+
+      <!-- Scan History Timeline -->
+      <div class="section-title">Scan History</div>
+      <div class="card" id="scan-history" style="margin-bottom:24px"></div>
+
+      <!-- Articles -->
+      <div class="section-title">Classified Articles <span class="count" id="articles-count"></span></div>
+      <div style="margin-bottom:8px">
+        <select id="intel-competitor-filter" onchange="filterIntelArticles()" style="width:auto;padding:4px 8px;font-size:12px">
+          <option value="">All Competitors</option>
+        </select>
+        <select id="intel-sort" onchange="filterIntelArticles()" style="width:auto;padding:4px 8px;font-size:12px;margin-left:4px">
+          <option value="relevance">By Relevance</option>
+          <option value="impact">By Impact</option>
+        </select>
       </div>
-      <div class="section-title" style="margin-top:16px">Trends</div>
-      <div class="card" id="trends-list"></div>
-      <div class="section-title" style="margin-top:16px">Competitor Profiles</div>
-      <div class="card" id="competitors-list"></div>
+      <div class="card" id="articles-list" style="max-height:500px;overflow-y:auto"></div>
     </div>
 
     <!-- SENTIMENT PAGE -->
@@ -875,66 +896,210 @@ async function loadDashboard() {
 }
 
 // --- Intel Monitor ---
+let _intelArticles = []; // cache for filtering
+
+function _unwrapAnalysis(obj) {
+  // Analysis data may be nested: {threats: {threats: [...]}} or flat: {threats: [...]}
+  if (!obj) return [];
+  if (Array.isArray(obj)) return obj;
+  // Look for a key matching common names
+  for (const k of Object.keys(obj)) {
+    if (Array.isArray(obj[k])) return obj[k];
+  }
+  return [];
+}
+
+function severityColor(score) {
+  if (score >= 8) return 'var(--red)';
+  if (score >= 5) return 'var(--orange)';
+  return 'var(--yellow)';
+}
+
+function severityBorder(score) {
+  if (score >= 8) return 'rgba(248,81,73,0.4)';
+  if (score >= 5) return 'rgba(210,153,34,0.4)';
+  return 'rgba(227,179,65,0.4)';
+}
+
 async function loadIntel() {
+  showLoading('intel-summary');
   showLoading('intel-stats');
-  showLoading('threats-list');
-  showLoading('opps-list');
+  showLoading('threats-grid');
+  showLoading('opps-grid');
   showLoading('trends-list');
-  showLoading('competitors-list');
+  showLoading('scan-history');
+  showLoading('articles-list');
 
   try {
-    const data = await api('/api/intel/latest');
+    const [data, history] = await Promise.all([
+      api('/api/intel/latest'),
+      api('/api/intel/history'),
+    ]);
+
     if (data.error) {
+      document.getElementById('intel-summary').innerHTML = emptyState('&#9673;', 'No scan data', data.error, '<button class="btn btn-primary btn-sm" onclick="triggerScan()">Run First Scan</button>');
       document.getElementById('intel-stats').innerHTML = '';
-      document.getElementById('threats-list').innerHTML = emptyState('&#9673;', 'No scan data', data.error, '<button class="btn btn-primary btn-sm" onclick="triggerScan()">Run First Scan</button>');
-      document.getElementById('opps-list').innerHTML = emptyState('&#9673;', 'No opportunities yet', 'Run a scan to discover opportunities');
-      document.getElementById('trends-list').innerHTML = emptyState('&#9673;', 'No trends identified', 'Trends emerge after scanning');
-      document.getElementById('competitors-list').innerHTML = emptyState('&#9673;', 'No competitor profiles', 'Profiles are built from scan data');
+      document.getElementById('threats-grid').innerHTML = '';
+      document.getElementById('opps-grid').innerHTML = '';
+      document.getElementById('trends-list').innerHTML = '';
+      document.getElementById('scan-history').innerHTML = '';
+      document.getElementById('articles-list').innerHTML = '';
       return;
     }
 
     const analysis = data.analysis || {};
-    const threats = analysis.threats || [];
-    const opps = analysis.opportunities || [];
-    const trends = analysis.trends || [];
-    const profiles = analysis.profiles || [];
+    const threats = _unwrapAnalysis(analysis.threats);
+    const opps = _unwrapAnalysis(analysis.opportunities);
+    const trends = _unwrapAnalysis(analysis.trends);
     const classified = data.classified?.intel || data.classified?.filtered || [];
+    const articles = data.articles || [];
+    const runMeta = data.run || {};
 
+    _intelArticles = classified;
+
+    // --- Summary card ---
+    const scanDate = data.scan_date || 'Unknown';
+    const runId = data.run_id || '';
+    const statusBadge = runMeta.status === 'completed' ? '<span class="tag tag-green">Completed</span>' : statusTag(runMeta.status || 'unknown');
+    document.getElementById('intel-summary').innerHTML = `
+      <div style="display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:12px">
+        <div>
+          <h3 style="color:var(--text);font-size:15px;margin-bottom:4px">Latest Scan: ${scanDate}</h3>
+          <div style="font-size:12px;color:var(--text3)">Run: ${runId}${runMeta.started_at ? ' &middot; ' + new Date(runMeta.started_at).toLocaleString() : ''}</div>
+        </div>
+        <div style="display:flex;gap:16px;align-items:center">
+          <div style="text-align:center"><div style="font-size:20px;font-weight:700">${articles.length || runMeta.articles_collected || 0}</div><div style="font-size:11px;color:var(--text3)">Articles</div></div>
+          <div style="text-align:center"><div style="font-size:20px;font-weight:700;color:var(--red)">${threats.length}</div><div style="font-size:11px;color:var(--text3)">Threats</div></div>
+          <div style="text-align:center"><div style="font-size:20px;font-weight:700;color:var(--green)">${opps.length}</div><div style="font-size:11px;color:var(--text3)">Opportunities</div></div>
+          <div>${statusBadge}</div>
+        </div>
+      </div>
+    `;
+
+    // --- Stats cards ---
     document.getElementById('intel-stats').innerHTML = [
-      `<div class="card card-sm"><h3>Classified Intel</h3><div class="value">${classified.length}</div></div>`,
-      `<div class="card card-sm"><h3>Threats</h3><div class="value" style="color:var(--red)">${threats.length}</div></div>`,
-      `<div class="card card-sm"><h3>Opportunities</h3><div class="value" style="color:var(--green)">${opps.length}</div></div>`,
+      `<div class="card card-sm"><h3>Total Articles</h3><div class="value">${articles.length || runMeta.articles_collected || 0}</div><div class="sub">collected from feeds</div></div>`,
+      `<div class="card card-sm"><h3>Classified Intel</h3><div class="value" style="color:var(--accent)">${classified.length}</div><div class="sub">relevance-scored</div></div>`,
+      `<div class="card card-sm"><h3>Threats</h3><div class="value" style="color:var(--red)">${threats.length}</div><div class="sub">competitive threats</div></div>`,
+      `<div class="card card-sm"><h3>Opportunities</h3><div class="value" style="color:var(--green)">${opps.length}</div><div class="sub">actionable opps</div></div>`,
     ].join('');
 
-    document.getElementById('threats-list').innerHTML = threats.length ? threats.map(t =>
-      `<div class="list-item"><div class="list-item-title">${t.description || t.threat_type}</div><div class="list-item-meta"><span>Severity: ${scoreBar(t.severity, 10, 'var(--red)')}</span><span>${t.timeframe || ''}</span></div>${t.defensive_action ? `<div style="font-size:12px;color:var(--text2);margin-top:4px">Action: ${t.defensive_action}</div>` : ''}</div>`
-    ).join('') : emptyState('&#9888;', 'No threats detected', 'Good news — no competitive threats found in latest scan');
+    // --- Threats cards ---
+    document.getElementById('threats-count').textContent = `(${threats.length})`;
+    document.getElementById('threats-grid').innerHTML = threats.length ? threats.map(t => {
+      const sev = t.severity || 0;
+      const borderCol = severityBorder(sev);
+      const sevCol = severityColor(sev);
+      return `<div class="card" style="border-color:${borderCol};border-left:3px solid ${sevCol}">
+        <div style="display:flex;justify-content:space-between;align-items:start;margin-bottom:8px">
+          <div style="font-weight:600;font-size:13px;color:var(--text)">${escapeHtml(t.title || t.threat_type || 'Unknown Threat')}</div>
+          <span class="tag" style="background:${sevCol}20;color:${sevCol};white-space:nowrap;margin-left:8px">${sev}/10</span>
+        </div>
+        <div style="font-size:12px;color:var(--text2);margin-bottom:8px">${escapeHtml(t.description || '')}</div>
+        <div style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:8px">
+          ${t.source_competitor ? `<span class="tag tag-blue">${t.source_competitor}</span>` : ''}
+          ${t.timeframe ? `<span class="tag tag-gray">${t.timeframe}</span>` : ''}
+          ${t.threat_type ? `<span class="tag tag-gray">${t.threat_type}</span>` : ''}
+        </div>
+        ${t.defensive_action ? `<div style="font-size:11px;color:var(--orange);border-top:1px solid var(--border);padding-top:8px"><strong>Defensive action:</strong> ${escapeHtml(t.defensive_action)}</div>` : ''}
+      </div>`;
+    }).join('') : emptyState('&#9888;', 'No threats detected', 'Good news &mdash; no competitive threats found');
 
-    document.getElementById('opps-list').innerHTML = opps.length ? opps.map(o =>
-      `<div class="list-item"><div class="list-item-title">${o.description || o.opportunity_type}</div><div class="list-item-meta"><span>Value: ${scoreBar(o.potential_value, 10, 'var(--green)')}</span><span>Feasibility: ${o.feasibility}/10</span></div></div>`
-    ).join('') : emptyState('&#10003;', 'No opportunities found', 'Opportunities will appear after analysis');
+    // --- Opportunities cards ---
+    document.getElementById('opps-count').textContent = `(${opps.length})`;
+    document.getElementById('opps-grid').innerHTML = opps.length ? opps.map(o => {
+      const val = o.potential_value || 0;
+      const feas = o.feasibility || 0;
+      return `<div class="card" style="border-color:rgba(63,185,80,0.3);border-left:3px solid var(--green)">
+        <div style="font-weight:600;font-size:13px;color:var(--text);margin-bottom:6px">${escapeHtml(o.title || o.opportunity_type || 'Opportunity')}</div>
+        <div style="font-size:12px;color:var(--text2);margin-bottom:8px">${escapeHtml(o.description || '')}</div>
+        <div style="display:flex;gap:16px;margin-bottom:8px">
+          <div style="font-size:11px"><span style="color:var(--text3)">Value:</span> <strong style="color:var(--green)">${val}/10</strong></div>
+          <div style="font-size:11px"><span style="color:var(--text3)">Feasibility:</span> <strong style="color:var(--accent)">${feas}/10</strong></div>
+          ${o.opportunity_type ? `<span class="tag tag-gray" style="font-size:10px">${o.opportunity_type}</span>` : ''}
+        </div>
+        ${o.action_items && o.action_items.length ? `<div style="font-size:11px;border-top:1px solid var(--border);padding-top:8px;color:var(--text2)"><strong>Actions:</strong><ul style="margin:4px 0 0 16px;padding:0">${o.action_items.map(a => `<li style="margin-bottom:2px">${escapeHtml(a)}</li>`).join('')}</ul></div>` : ''}
+      </div>`;
+    }).join('') : emptyState('&#10003;', 'No opportunities found', 'Opportunities will appear after analysis');
 
+    // --- Trends table ---
+    document.getElementById('trends-count').textContent = `(${trends.length})`;
     document.getElementById('trends-list').innerHTML = trends.length ?
-      `<div class="table-wrap"><table><thead><tr><th>Trend</th><th>Category</th><th>Direction</th><th>Strength</th></tr></thead><tbody>${trends.map(t =>
-        `<tr><td>${t.name}</td><td><span class="tag tag-purple">${t.category}</span></td><td>${t.direction}</td><td>${scoreBar(t.strength, 10)}</td></tr>`
+      `<div class="table-wrap"><table><thead><tr><th>Trend</th><th>Category</th><th>Direction</th><th>Strength</th><th>Tubi Implication</th></tr></thead><tbody>${trends.map(t =>
+        `<tr><td><strong>${escapeHtml(t.name || '')}</strong><div style="font-size:11px;color:var(--text3);max-width:300px">${escapeHtml(t.description || '').substring(0, 120)}</div></td><td><span class="tag tag-purple">${t.category || ''}</span></td><td>${t.direction || ''}</td><td>${scoreBar(t.strength || 0, 10)}</td><td style="font-size:12px;max-width:250px;color:var(--text2)">${escapeHtml(t.tubi_implication || '').substring(0, 150)}</td></tr>`
       ).join('')}</tbody></table></div>` : emptyState('&#8635;', 'No trends identified', 'Trends emerge from repeated scan analysis');
 
-    document.getElementById('competitors-list').innerHTML = profiles.length ?
-      `<div class="table-wrap"><table><thead><tr><th>Competitor</th><th>Tier</th><th>Channels</th><th>Threat</th><th>Strategy</th></tr></thead><tbody>${profiles.map(p =>
-        `<tr><td><strong>${p.name}</strong></td><td>${p.tier}</td><td>${p.channel_count || '—'}</td><td>${scoreBar(p.threat_level, 10, 'var(--red)')}</td><td style="font-size:12px;max-width:300px">${p.strategy_focus || ''}</td></tr>`
-      ).join('')}</tbody></table></div>` : emptyState('&#9635;', 'No competitor profiles', 'Profiles are built from scan data');
+    // --- Scan history ---
+    const historyList = Array.isArray(history) ? history : [];
+    document.getElementById('scan-history').innerHTML = historyList.length ?
+      `<div class="table-wrap"><table><thead><tr><th>Date</th><th>Run ID</th><th>Status</th><th>Articles</th><th>Classified</th><th>Threats</th><th>Opps</th><th>Analysis</th></tr></thead><tbody>${historyList.map(h =>
+        `<tr><td>${h.date}</td><td style="font-family:monospace;font-size:11px">${h.run_id}</td><td>${statusTag(h.status)}</td><td>${h.article_count}</td><td>${h.classified_count}</td><td style="color:${h.threat_count > 0 ? 'var(--red)' : 'var(--text3)'}">${h.threat_count}</td><td style="color:${h.opportunity_count > 0 ? 'var(--green)' : 'var(--text3)'}">${h.opportunity_count}</td><td>${h.has_analysis ? '<span class="tag tag-green">yes</span>' : '<span class="tag tag-gray">no</span>'}</td></tr>`
+      ).join('')}</tbody></table></div>` : emptyState('&#8635;', 'No scan history', 'Run scans to build history');
+
+    // --- Articles list ---
+    // Build competitor filter options
+    const competitors = [...new Set(classified.map(a => a.competitor_id).filter(Boolean))].sort();
+    const filterEl = document.getElementById('intel-competitor-filter');
+    filterEl.innerHTML = '<option value="">All Competitors</option>' + competitors.map(c => `<option value="${c}">${c}</option>`).join('');
+
+    renderIntelArticles(classified);
+
+    // Ensure threats/opportunities are in work queue (idempotent)
+    api('/api/intel/ensure-work-items', { method: 'POST' }).catch(() => {});
+
   } catch (err) {
-    // Error already shown via toast
+    document.getElementById('intel-summary').innerHTML = emptyState('&#9888;', 'Failed to load intel', 'Check server connection', '<button class="btn btn-sm" onclick="loadIntel()">Retry</button>');
   }
+}
+
+function renderIntelArticles(articles) {
+  document.getElementById('articles-count').textContent = `(${articles.length})`;
+  document.getElementById('articles-list').innerHTML = articles.length ? articles.map(a => {
+    const relScore = a.relevance_score || 0;
+    const impScore = a.impact_score || 0;
+    const relColor = relScore >= 7 ? 'var(--green)' : relScore >= 4 ? 'var(--orange)' : 'var(--text3)';
+    const impColor = impScore >= 7 ? 'var(--red)' : impScore >= 4 ? 'var(--orange)' : 'var(--text3)';
+    return `<div class="list-item">
+      <div style="display:flex;justify-content:space-between;align-items:start">
+        <div class="list-item-title" style="flex:1">${a.url ? `<a href="${escapeHtml(a.url)}" target="_blank" style="color:var(--accent);text-decoration:none">${escapeHtml(a.title || 'Untitled')}</a>` : escapeHtml(a.title || 'Untitled')}</div>
+        <div style="display:flex;gap:8px;margin-left:8px;white-space:nowrap">
+          <span style="font-size:11px;color:${relColor}">Rel: ${relScore}</span>
+          <span style="font-size:11px;color:${impColor}">Imp: ${impScore}</span>
+        </div>
+      </div>
+      ${a.summary ? `<div style="font-size:12px;color:var(--text2);margin-top:4px">${escapeHtml(a.summary).substring(0, 200)}</div>` : ''}
+      <div class="list-item-meta" style="margin-top:4px">
+        ${a.competitor_id ? `<span class="tag tag-blue" style="font-size:10px">${a.competitor_id}</span>` : ''}
+        ${a.category ? `<span class="tag tag-gray" style="font-size:10px">${a.category}</span>` : ''}
+        ${a.published_at ? `<span>${a.published_at}</span>` : ''}
+      </div>
+    </div>`;
+  }).join('') : emptyState('&#9673;', 'No classified articles', 'Articles appear after scan classification');
+}
+
+function filterIntelArticles() {
+  const competitor = document.getElementById('intel-competitor-filter').value;
+  const sort = document.getElementById('intel-sort').value;
+  let filtered = _intelArticles;
+  if (competitor) {
+    filtered = filtered.filter(a => a.competitor_id === competitor);
+  }
+  filtered = [...filtered].sort((a, b) => {
+    if (sort === 'impact') return (b.impact_score || 0) - (a.impact_score || 0);
+    return (b.relevance_score || 0) - (a.relevance_score || 0);
+  });
+  renderIntelArticles(filtered);
 }
 
 async function triggerScan() {
   try {
-    showToast('Starting competitive scan...', 'info');
+    document.getElementById('intel-scan-note').textContent = 'Scan starting... (takes ~60s)';
+    showToast('Starting competitive scan... This takes about 60 seconds.', 'info', 10000);
     const r = await api('/api/intel/scan', { method: 'POST' });
-    showToast('Scan started successfully', 'success');
+    showToast('Scan started in background. Refresh in ~60s to see results.', 'success', 15000);
+    document.getElementById('intel-scan-note').textContent = 'Scan running in background...';
   } catch (err) {
-    // Error toast already shown
+    document.getElementById('intel-scan-note').textContent = '';
   }
 }
 


### PR DESCRIPTION
## Summary

- **Backend**: Fixed `/api/intel/latest` to intelligently merge data across scan runs (latest run often lacks classified intel or analysis data). Added `/api/intel/ensure-work-items` endpoint to idempotently push threats/opportunities into the work queue. Fixed nested analysis structure unwrapping in `/api/intel/threats`, `/opportunities`, `/trends`, `/competitors`. Enhanced `/api/intel/history` to read actual file contents for accurate counts.
- **Frontend**: Complete rebuild of Intel Monitor page with summary card, threat cards (severity-colored), opportunity cards (green with action items), trends table, scan history timeline, and filterable classified articles list.
- **Fixes**: Python 3.9 compatibility for type annotations in `db.py` and `ask.py`.

## Verified Endpoints

| Endpoint | Status | Data |
|----------|--------|------|
| `GET /api/intel/latest` | Working | 141 articles, 25 classified, 3 threats, 5 opps |
| `GET /api/intel/threats` | Working | YouTube TV cheaper plans (sev 8), Samsung 100M users (sev 7), Cineverse AI (sev 6) |
| `GET /api/intel/opportunities` | Working | 5 opportunities with value/feasibility scores |
| `GET /api/intel/history` | Working | 7 scan runs with accurate counts |
| `GET /api/intel/diff` | Working | Comparison of latest two runs |
| `POST /api/intel/scan` | Working | Triggers background scan |
| `POST /api/intel/ensure-work-items` | Working | Idempotent, created 8 work items on first call |

## Test plan

- [ ] Navigate to Intel Monitor page at localhost:8888
- [ ] Verify summary card shows scan date, article count, threats, opportunities
- [ ] Verify threat cards display with red/orange severity coloring
- [ ] Verify opportunity cards display with green coloring and action items
- [ ] Verify trends table populates
- [ ] Verify scan history timeline shows past runs
- [ ] Verify articles list is filterable by competitor
- [ ] Click "Run New Scan" button and verify it triggers
- [ ] Check Work Queue page — threats and opportunities should appear as work items

## Notes

- The latest scan run (175003) has analysis but 0 classified articles. Earlier runs (153300, 150544) have classified data. The new `_find_best_run()` merges across runs to present the fullest picture.
- `data/` directory (SQLite DB) is gitignored and auto-created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)