### PR TITLE
Fix /api/ask 500 error (issue #36)

### DIFF
--- a/hub/routers/ask.py
+++ b/hub/routers/ask.py
@@ -210,10 +210,10 @@ def ask(req: AskRequest):
     # Step 5: Log to history
     db.log_ask(
         question=question,
-        sql_text=sql,
+        sql=sql,
         results=rows_data,
         summary=summary,
-        row_count=len(rows_data),
+        rows=len(rows_data),
         elapsed_sec=round(elapsed, 2),
     )
 


### PR DESCRIPTION
## Summary
- Fixed `db.log_ask()` call in `hub/routers/ask.py` using wrong keyword argument names (`sql_text` instead of `sql`, `row_count` instead of `rows`), which caused a `TypeError` on every successful query execution
- Verified all three routers (problems, insights, ask) are properly registered in `server.py` and all GET endpoints return 200
- POST `/api/ask` returns 500 only when `OPENAI_API_KEY` is not configured, which is the intended behavior

## What was investigated
The issue reported all three API groups returning 404 or 500. Investigation found:
1. All routers **are** registered in `server.py` `_ROUTER_NAMES` list — no 404 issue
2. All routers import cleanly — no import chain failures  
3. The only bug was mismatched keyword arguments in `ask.py:211-218` causing `TypeError` on the successful code path

## Test plan
- [x] Verified `python3 -c 'import hub.routers.problems'` — clean import
- [x] Verified `python3 -c 'import hub.routers.insights'` — clean import
- [x] Verified `python3 -c 'import hub.routers.ask'` — clean import
- [x] Verified all GET endpoints return 200 via FastAPI TestClient
- [x] Verified POST `/api/ask` returns expected 500 when OPENAI_API_KEY missing

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)